### PR TITLE
feat(storyboard): add readiness check

### DIFF
--- a/src/components/StoryboardReadinessPanel.tsx
+++ b/src/components/StoryboardReadinessPanel.tsx
@@ -1,0 +1,115 @@
+import { AlertTriangle, CheckCircle2, Sparkles } from "lucide-react";
+import type { Storyboard } from "../types/sketch";
+import type { StoryboardReadinessSummary } from "../utils/storyboardReadiness";
+
+interface StoryboardReadinessPanelProps {
+  storyboard: Storyboard;
+  readiness: StoryboardReadinessSummary;
+  locked: boolean;
+  onFixWithAi: () => void;
+}
+
+export function StoryboardReadinessPanel({
+  storyboard,
+  readiness,
+  locked,
+  onFixWithAi,
+}: StoryboardReadinessPanelProps) {
+  const ready = readiness.status === "ready";
+
+  return (
+    <section className="mb-6 rounded-2xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-alt))]/55 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 rounded-full p-1.5 ${ready ? "bg-[rgb(var(--color-success))]/10 text-[rgb(var(--color-success))]" : "bg-[rgb(var(--color-warning))]/10 text-[rgb(var(--color-warning))]"}`}>
+            {ready ? <CheckCircle2 className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
+          </div>
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-sm font-semibold text-[rgb(var(--color-text))]">Readiness Check</h2>
+              <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${ready ? "bg-[rgb(var(--color-success))]/10 text-[rgb(var(--color-success))]" : "bg-[rgb(var(--color-warning))]/10 text-[rgb(var(--color-warning))]"}`}>
+                {ready ? "Ready" : "Needs Work"}
+              </span>
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-[rgb(var(--color-text-secondary))]">
+              {ready
+                ? `${storyboard.title} has ${readiness.totalRows} ready-to-record rows.`
+                : `${readiness.incompleteSketches.length + readiness.unloadedSketches.length} sketch${readiness.incompleteSketches.length + readiness.unloadedSketches.length === 1 ? "" : "es"} need attention before recording.`}
+            </p>
+          </div>
+        </div>
+
+        {!ready && !locked && (
+          <button
+            type="button"
+            onClick={onFixWithAi}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-[rgb(var(--color-accent))] hover:bg-[rgb(var(--color-accent))]/10 transition-colors"
+            title="Ask the AI assistant to fix readiness gaps without touching locked rows"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            Fix gaps with AI
+          </button>
+        )}
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+        <Metric label="Rows" value={readiness.totalRows} />
+        <Metric label="No timing" value={readiness.missingTiming} warn={readiness.missingTiming > 0} />
+        <Metric label="No narration" value={readiness.missingNarration} warn={readiness.missingNarration > 0} />
+        <Metric label="No actions" value={readiness.missingDemoActions} warn={readiness.missingDemoActions > 0} />
+        <Metric label="Vague actions" value={readiness.vagueDemoActions} warn={readiness.vagueDemoActions > 0} />
+        <Metric label="No visual" value={readiness.missingVisuals} warn={readiness.missingVisuals > 0} />
+      </div>
+
+      {!ready && (
+        <div className="mt-4 grid gap-3 md:grid-cols-[1.25fr_1fr]">
+          <div>
+            <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-[rgb(var(--color-text-secondary))]">
+              Incomplete sketches
+            </h3>
+            <div className="space-y-1.5">
+              {[...readiness.incompleteSketches, ...readiness.unloadedSketches].slice(0, 4).map((sketch) => (
+                <div key={`${sketch.path}-${sketch.loaded ? "loaded" : "loading"}`} className="flex items-center justify-between gap-3 rounded-lg border border-[rgb(var(--color-border))]/70 bg-[rgb(var(--color-surface))]/65 px-3 py-2">
+                  <span className="truncate text-xs font-medium text-[rgb(var(--color-text))]">{sketch.title}</span>
+                  <span className="shrink-0 text-[10px] text-[rgb(var(--color-text-secondary))]">
+                    {sketch.loaded ? `${sketch.issueCount} gap${sketch.issueCount === 1 ? "" : "s"}` : "loading"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-[rgb(var(--color-text-secondary))]">
+              Next steps
+            </h3>
+            <ul className="space-y-1.5">
+              {readiness.nextSteps.map((step) => (
+                <li key={step} className="text-xs leading-relaxed text-[rgb(var(--color-text-secondary))]">
+                  {step}
+                </li>
+              ))}
+            </ul>
+            {readiness.lockedIssueRows > 0 && (
+              <p className="mt-2 text-[11px] leading-relaxed text-[rgb(var(--color-warning))]">
+                {readiness.lockedIssueRows} row{readiness.lockedIssueRows === 1 ? "" : "s"} with gaps are locked and will be skipped by AI fixes.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Metric({ label, value, warn = false }: { label: string; value: number; warn?: boolean }) {
+  return (
+    <div className="rounded-xl border border-[rgb(var(--color-border))]/70 bg-[rgb(var(--color-surface))]/65 px-3 py-2">
+      <div className={`text-lg font-semibold ${warn ? "text-[rgb(var(--color-warning))]" : "text-[rgb(var(--color-text))]"}`}>
+        {value}
+      </div>
+      <div className="text-[10px] font-medium uppercase tracking-wide text-[rgb(var(--color-text-secondary))]">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StoryboardView.tsx
+++ b/src/components/StoryboardView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -33,8 +33,14 @@ import { SketchPickerItem } from "./SketchCard";
 import { ScriptTable } from "./ScriptTable";
 import { exportStoryboardToWord } from "../utils/exportToWord";
 import { ExportWordButton } from "./ExportWordButton";
+import { StoryboardReadinessPanel } from "./StoryboardReadinessPanel";
 import type { Sketch, SketchSummary } from "../types/sketch";
 import type { PreviewSlide } from "./SketchPreview";
+import {
+  buildStoryboardReadiness,
+  formatReadinessPrompt,
+  getStoryboardSketchPaths,
+} from "../utils/storyboardReadiness";
 
 interface MonitorInfo {
   id: number;
@@ -82,7 +88,7 @@ export function StoryboardView() {
   const pendingDescRef = useRef<string | null>(null);
   const [availableMonitors, setAvailableMonitors] = useState<MonitorInfo[]>([]);
 
-  const sketchMap = new Map(sketches.map((s) => [s.path, s]));
+  const sketchMap = useMemo(() => new Map(sketches.map((s) => [s.path, s])), [sketches]);
   const storyboardLocked = activeStoryboard?.locked ?? false;
 
   // Reset the local description when switching storyboards.
@@ -137,16 +143,29 @@ export function StoryboardView() {
   // Eagerly load all referenced sketches
   useEffect(() => {
     if (!activeStoryboard) return;
-    for (const item of activeStoryboard.items) {
-      if (item.type === "sketch_ref" && !sketchCache.has(item.path) && !loadingRef.current.has(item.path)) {
-        loadingRef.current.add(item.path);
-        invoke<Sketch>("get_sketch", { relativePath: item.path })
-          .then((sketch) => setSketchCache((prev) => new Map(prev).set(item.path, sketch)))
+    for (const path of getStoryboardSketchPaths(activeStoryboard)) {
+      if (!sketchCache.has(path) && !loadingRef.current.has(path)) {
+        loadingRef.current.add(path);
+        invoke<Sketch>("get_sketch", { relativePath: path })
+          .then((sketch) => setSketchCache((prev) => new Map(prev).set(path, sketch)))
           .catch((err) => console.error("Failed to load sketch:", err))
-          .finally(() => loadingRef.current.delete(item.path));
+          .finally(() => loadingRef.current.delete(path));
       }
     }
   }, [activeStoryboard, sketchCache]);
+
+  const readiness = useMemo(() => {
+    if (!activeStoryboard) return null;
+    return buildStoryboardReadiness(activeStoryboard, sketchCache, sketchMap);
+  }, [activeStoryboard, sketchCache, sketchMap]);
+
+  const handleFixReadinessWithAi = useCallback(() => {
+    if (!activeStoryboard || !readiness) return;
+    sendChatPrompt(
+      `${formatReadinessPrompt(activeStoryboard, readiness)}\n\nStoryboard path: "${activeStoryboardPath}".`,
+      { silent: true },
+    );
+  }, [activeStoryboard, activeStoryboardPath, readiness, sendChatPrompt]);
 
   /** Build typed slides for preview: storyboard title → (sketch title → sketch rows)... */
   const buildPreviewSlides = useCallback((): PreviewSlide[] => {
@@ -432,6 +451,15 @@ export function StoryboardView() {
             Generate sketch
           </button>
         </div>
+        )}
+
+        {readiness && (
+          <StoryboardReadinessPanel
+            storyboard={activeStoryboard}
+            readiness={readiness}
+            locked={storyboardLocked}
+            onFixWithAi={handleFixReadinessWithAi}
+          />
         )}
 
         {/* Items */}

--- a/src/test/storyboardReadiness.test.ts
+++ b/src/test/storyboardReadiness.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStoryboardReadiness,
+  formatReadinessPrompt,
+  getStoryboardSketchPaths,
+} from "../utils/storyboardReadiness";
+import type { Sketch, Storyboard } from "../types/sketch";
+
+function storyboard(items: Storyboard["items"]): Storyboard {
+  return {
+    title: "Launch Demo",
+    description: "",
+    items,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function sketch(title: string, rows: Sketch["rows"], locked = false): Sketch {
+  return {
+    title,
+    locked,
+    description: "",
+    rows,
+    state: "draft",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("storyboard readiness", () => {
+  it("reports ready when every row has timing, narration, actions, and a visual cue", () => {
+    const sb = storyboard([{ type: "sketch_ref", path: "intro.sk" }]);
+    const sketches = new Map([
+      ["intro.sk", sketch("Intro", [
+        {
+          time: "0:00-0:15",
+          narrative: "Introduce the problem.",
+          demo_actions: "Open the dashboard and point to the project list.",
+          screenshot: "screenshots/dashboard.png",
+        },
+      ])],
+    ]);
+
+    const readiness = buildStoryboardReadiness(sb, sketches);
+
+    expect(readiness.status).toBe("ready");
+    expect(readiness.totalRows).toBe(1);
+    expect(readiness.nextSteps).toEqual(["Ready to record."]);
+  });
+
+  it("counts missing fields, vague actions, and missing screenshot or visual coverage", () => {
+    const sb = storyboard([{ type: "sketch_ref", path: "setup.sk" }]);
+    const sketches = new Map([
+      ["setup.sk", sketch("Setup", [
+        {
+          time: "",
+          narrative: "",
+          demo_actions: "",
+          screenshot: null,
+        },
+        {
+          time: "0:15-0:30",
+          narrative: "Show the configured workflow.",
+          demo_actions: "walk through",
+          screenshot: null,
+          visual: null,
+        },
+      ])],
+    ]);
+
+    const readiness = buildStoryboardReadiness(sb, sketches);
+
+    expect(readiness.status).toBe("needs-work");
+    expect(readiness.missingTiming).toBe(1);
+    expect(readiness.missingNarration).toBe(1);
+    expect(readiness.missingDemoActions).toBe(1);
+    expect(readiness.vagueDemoActions).toBe(1);
+    expect(readiness.missingVisuals).toBe(2);
+    expect(readiness.incompleteSketches).toHaveLength(1);
+  });
+
+  it("includes sketches nested in legacy storyboard sections", () => {
+    const sb = storyboard([
+      { type: "section", title: "Main flow", sketches: ["intro.sk", "outro.sk"] },
+    ]);
+
+    expect(getStoryboardSketchPaths(sb)).toEqual(["intro.sk", "outro.sk"]);
+  });
+
+  it("tells the AI prompt not to touch locked rows", () => {
+    const sb = storyboard([{ type: "sketch_ref", path: "locked.sk" }]);
+    const sketches = new Map([
+      ["locked.sk", sketch("Locked", [
+        {
+          locked: true,
+          time: "",
+          narrative: "",
+          demo_actions: "",
+          screenshot: null,
+        },
+      ])],
+    ]);
+    const readiness = buildStoryboardReadiness(sb, sketches);
+
+    const prompt = formatReadinessPrompt(sb, readiness);
+
+    expect(readiness.lockedIssueRows).toBe(1);
+    expect(prompt).toContain("do not edit this row");
+    expect(prompt).toContain("Do not modify locked rows or locked cells");
+  });
+
+  it("treats rows in locked sketches as non-editable for AI fixes", () => {
+    const sb = storyboard([{ type: "sketch_ref", path: "locked-sketch.sk" }]);
+    const sketches = new Map([
+      ["locked-sketch.sk", sketch("Locked Sketch", [
+        {
+          time: "",
+          narrative: "",
+          demo_actions: "",
+          screenshot: null,
+        },
+      ], true)],
+    ]);
+
+    const readiness = buildStoryboardReadiness(sb, sketches);
+    const prompt = formatReadinessPrompt(sb, readiness);
+
+    expect(readiness.lockedIssueRows).toBe(1);
+    expect(prompt).toContain("locked - do not edit this row");
+  });
+
+  it("names empty sketches as AI targets for planning-row creation", () => {
+    const sb = storyboard([{ type: "sketch_ref", path: "empty.sk" }]);
+    const sketches = new Map([
+      ["empty.sk", sketch("Empty Sketch", [])],
+    ]);
+
+    const readiness = buildStoryboardReadiness(sb, sketches);
+    const prompt = formatReadinessPrompt(sb, readiness);
+
+    expect(readiness.status).toBe("needs-work");
+    expect(readiness.incompleteSketches).toHaveLength(1);
+    expect(prompt).toContain("Sketches with no planning rows");
+    expect(prompt).toContain("Empty Sketch (empty.sk)");
+  });
+
+  it("reports unloaded sketches with a fallback title", () => {
+    const sb = storyboard([{ type: "sketch_ref", path: "missing.sk" }]);
+
+    const readiness = buildStoryboardReadiness(sb, new Map());
+
+    expect(readiness.status).toBe("needs-work");
+    expect(readiness.unloadedSketches).toEqual([
+      {
+        path: "missing.sk",
+        title: "missing.sk",
+        locked: false,
+        loaded: false,
+        rowCount: 0,
+        issueCount: 1,
+      },
+    ]);
+    expect(readiness.incompleteSketches).toEqual([]);
+  });
+});

--- a/src/utils/storyboardReadiness.ts
+++ b/src/utils/storyboardReadiness.ts
@@ -1,0 +1,300 @@
+import type { PlanningRow, Sketch, SketchSummary, Storyboard, StoryboardItem } from "../types/sketch";
+
+export type StoryboardReadinessStatus = "ready" | "needs-work";
+
+export interface RowReadinessIssue {
+  sketchPath: string;
+  sketchTitle: string;
+  rowNumber: number;
+  locked: boolean;
+  missingTiming: boolean;
+  missingNarration: boolean;
+  missingDemoActions: boolean;
+  vagueDemoActions: boolean;
+  missingVisuals: boolean;
+}
+
+export interface SketchReadinessSummary {
+  path: string;
+  title: string;
+  locked: boolean;
+  loaded: boolean;
+  rowCount: number;
+  issueCount: number;
+}
+
+export interface StoryboardReadinessSummary {
+  status: StoryboardReadinessStatus;
+  totalSketches: number;
+  loadedSketches: number;
+  totalRows: number;
+  missingTiming: number;
+  missingNarration: number;
+  missingDemoActions: number;
+  vagueDemoActions: number;
+  missingVisuals: number;
+  lockedIssueRows: number;
+  incompleteSketches: SketchReadinessSummary[];
+  unloadedSketches: SketchReadinessSummary[];
+  rowIssues: RowReadinessIssue[];
+  nextSteps: string[];
+}
+
+const VAGUE_ACTION_PATTERNS = [
+  /\btbd\b/i,
+  /\btodo\b/i,
+  /\bfix me\b/i,
+  /\bclick around\b/i,
+  /\bshow (the )?(feature|thing|stuff|page|screen)\b/i,
+  /\bdemo (this|it|feature)\b/i,
+  /\bwalk through\b/i,
+  /\bgo through\b/i,
+  /\badd actions?\b/i,
+  /\bfill (this )?in\b/i,
+];
+
+export function getStoryboardSketchPaths(storyboard: Storyboard): string[] {
+  return storyboard.items.flatMap((item) => getItemSketchPaths(item));
+}
+
+export function buildStoryboardReadiness(
+  storyboard: Storyboard,
+  sketchesByPath: Map<string, Sketch>,
+  summariesByPath: Map<string, SketchSummary> = new Map(),
+): StoryboardReadinessSummary {
+  const sketchPaths = getStoryboardSketchPaths(storyboard);
+  const rowIssues: RowReadinessIssue[] = [];
+  const incompleteSketches: SketchReadinessSummary[] = [];
+  const unloadedSketches: SketchReadinessSummary[] = [];
+
+  let totalRows = 0;
+  let missingTiming = 0;
+  let missingNarration = 0;
+  let missingDemoActions = 0;
+  let vagueDemoActions = 0;
+  let missingVisuals = 0;
+  let lockedIssueRows = 0;
+
+  for (const path of sketchPaths) {
+    const sketch = sketchesByPath.get(path);
+    const summary = summariesByPath.get(path);
+    const title = sketch?.title ?? summary?.title ?? path;
+    const locked = sketch?.locked ?? false;
+
+    if (!sketch) {
+      unloadedSketches.push({
+        path,
+        title,
+        locked,
+        loaded: false,
+        rowCount: summary?.row_count ?? 0,
+        issueCount: 1,
+      });
+      continue;
+    }
+
+    totalRows += sketch.rows.length;
+    let sketchIssueCount = sketch.rows.length === 0 ? 1 : 0;
+
+    sketch.rows.forEach((row, index) => {
+      const issue = buildRowIssue(path, title, sketch.locked ?? false, row, index);
+      if (!hasRowIssue(issue)) return;
+
+      rowIssues.push(issue);
+      sketchIssueCount += countRowIssue(issue);
+      if (issue.missingTiming) missingTiming += 1;
+      if (issue.missingNarration) missingNarration += 1;
+      if (issue.missingDemoActions) missingDemoActions += 1;
+      if (issue.vagueDemoActions) vagueDemoActions += 1;
+      if (issue.missingVisuals) missingVisuals += 1;
+      if (issue.locked) lockedIssueRows += 1;
+    });
+
+    if (sketchIssueCount > 0) {
+      incompleteSketches.push({
+        path,
+        title,
+        locked,
+        loaded: true,
+        rowCount: sketch.rows.length,
+        issueCount: sketchIssueCount,
+      });
+    }
+  }
+
+  const nextSteps = buildNextSteps({
+    totalSketches: sketchPaths.length,
+    totalRows,
+    missingTiming,
+    missingNarration,
+    missingDemoActions,
+    vagueDemoActions,
+    missingVisuals,
+    unloadedSketches: unloadedSketches.length,
+  });
+
+  return {
+    status: incompleteSketches.length === 0 && unloadedSketches.length === 0 && sketchPaths.length > 0
+      ? "ready"
+      : "needs-work",
+    totalSketches: sketchPaths.length,
+    loadedSketches: sketchPaths.length - unloadedSketches.length,
+    totalRows,
+    missingTiming,
+    missingNarration,
+    missingDemoActions,
+    vagueDemoActions,
+    missingVisuals,
+    lockedIssueRows,
+    incompleteSketches,
+    unloadedSketches,
+    rowIssues,
+    nextSteps,
+  };
+}
+
+export function formatReadinessPrompt(storyboard: Storyboard, summary: StoryboardReadinessSummary): string {
+  const emptySketches = summary.incompleteSketches
+    .filter((sketch) => sketch.loaded && sketch.rowCount === 0)
+    .map((sketch) => {
+      const lockNote = sketch.locked ? " (locked - do not edit this sketch)" : "";
+      return `- ${sketch.title} (${sketch.path})${lockNote}`;
+    })
+    .join("\n");
+
+  const issues = summary.rowIssues
+    .map((issue) => {
+      const parts = [
+        issue.missingTiming ? "missing timing" : null,
+        issue.missingNarration ? "missing narration" : null,
+        issue.missingDemoActions ? "missing demo actions" : null,
+        issue.vagueDemoActions ? "vague demo actions" : null,
+        issue.missingVisuals ? "missing screenshot/visual" : null,
+      ].filter(Boolean).join(", ");
+      const lockNote = issue.locked ? " (locked - do not edit this row or its locked cells)" : "";
+      return `- ${issue.sketchTitle} (${issue.sketchPath}) row ${issue.rowNumber}: ${parts}${lockNote}`;
+    })
+    .join("\n");
+
+  const unloaded = summary.unloadedSketches
+    .map((sketch) => `- ${sketch.title} (${sketch.path})`)
+    .join("\n");
+
+  return [
+    `Fix readiness gaps for the storyboard "${storyboard.title}".`,
+    "Use the storyboard and sketch tools to update only rows that are not locked. Do not modify locked rows or locked cells.",
+    `Current readiness status: ${summary.status === "ready" ? "Ready" : "Needs Work"}.`,
+    `Totals: ${summary.totalRows} rows, ${summary.missingTiming} missing timing, ${summary.missingNarration} missing narration, ${summary.missingDemoActions} missing demo actions, ${summary.vagueDemoActions} vague demo actions, ${summary.missingVisuals} missing screenshots/visuals.`,
+    emptySketches ? `Sketches with no planning rows:\n${emptySketches}` : "",
+    issues ? `Rows to fix:\n${issues}` : "No row-level gaps were detected.",
+    unloaded ? `First load or inspect these sketches before editing:\n${unloaded}` : "",
+    "Add concise timing, narration, concrete demo actions, and screenshot/visual guidance where appropriate. When finished, summarize what changed.",
+  ].filter(Boolean).join("\n\n");
+}
+
+function getItemSketchPaths(item: StoryboardItem): string[] {
+  if (item.type === "sketch_ref") return [item.path];
+  return item.sketches;
+}
+
+function buildRowIssue(
+  sketchPath: string,
+  sketchTitle: string,
+  sketchLocked: boolean,
+  row: PlanningRow,
+  rowIndex: number,
+): RowReadinessIssue {
+  const missingDemoActions = isBlank(row.demo_actions);
+  const missingTiming = isBlank(row.time);
+  const missingNarration = isBlank(row.narrative);
+  const vagueDemoActions = !missingDemoActions && isVagueAction(row.demo_actions);
+  const missingVisuals = isBlank(row.screenshot) && isBlank(row.visual);
+
+  return {
+    sketchPath,
+    sketchTitle,
+    rowNumber: rowIndex + 1,
+    locked: isIssueLocked(row, sketchLocked, {
+      missingTiming,
+      missingNarration,
+      missingDemoActions,
+      vagueDemoActions,
+      missingVisuals,
+    }),
+    missingTiming,
+    missingNarration,
+    missingDemoActions,
+    vagueDemoActions,
+    missingVisuals,
+  };
+}
+
+function isBlank(value: string | null | undefined): boolean {
+  return !value || value.trim().length === 0;
+}
+
+function isVagueAction(value: string): boolean {
+  const normalized = value.trim();
+  if (normalized.length < 4) return true;
+  return VAGUE_ACTION_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function hasRowIssue(issue: RowReadinessIssue): boolean {
+  return countRowIssue(issue) > 0;
+}
+
+function countRowIssue(issue: RowReadinessIssue): number {
+  return [
+    issue.missingTiming,
+    issue.missingNarration,
+    issue.missingDemoActions,
+    issue.vagueDemoActions,
+    issue.missingVisuals,
+  ].filter(Boolean).length;
+}
+
+function isIssueLocked(
+  row: PlanningRow,
+  sketchLocked: boolean,
+  issues: {
+    missingTiming: boolean;
+    missingNarration: boolean;
+    missingDemoActions: boolean;
+    vagueDemoActions: boolean;
+    missingVisuals: boolean;
+  },
+): boolean {
+  if (sketchLocked || row.locked) return true;
+  const locks = row.locks ?? {};
+  return Boolean(
+    (issues.missingTiming && locks.time) ||
+    (issues.missingNarration && locks.narrative) ||
+    ((issues.missingDemoActions || issues.vagueDemoActions) && locks.demo_actions) ||
+    (issues.missingVisuals && locks.screenshot && locks.visual),
+  );
+}
+
+function buildNextSteps(input: {
+  totalSketches: number;
+  totalRows: number;
+  missingTiming: number;
+  missingNarration: number;
+  missingDemoActions: number;
+  vagueDemoActions: number;
+  missingVisuals: number;
+  unloadedSketches: number;
+}): string[] {
+  if (input.totalSketches === 0) return ["Add at least one sketch to the storyboard."];
+  if (input.unloadedSketches > 0) return ["Finish loading referenced sketches, then run the readiness check again."];
+  if (input.totalRows === 0) return ["Add planning rows to the storyboard sketches."];
+
+  const steps: string[] = [];
+  if (input.missingTiming > 0) steps.push("Fill in timing for rows that do not yet have pacing.");
+  if (input.missingNarration > 0) steps.push("Add narration so the presenter knows what to say.");
+  if (input.missingDemoActions > 0 || input.vagueDemoActions > 0) {
+    steps.push("Replace missing or vague demo actions with concrete steps.");
+  }
+  if (input.missingVisuals > 0) steps.push("Attach a screenshot or visual cue to each uncovered row.");
+  if (steps.length === 0) steps.push("Ready to record.");
+  return steps;
+}


### PR DESCRIPTION
## Summary
- add a storyboard Readiness Check panel with Ready / Needs Work status
- summarize missing timing, narration, demo actions, vague actions, and screenshot/visual gaps
- add AI fix prompt that avoids locked rows, locked cells, and locked sketches
- cover readiness scoring, section sketch paths, locked content, empty sketches, and unloaded sketches with tests

## Validation
- npx tsc --noEmit
- npx vitest run
- npm run build