### PR TITLE
feat(storyboard): add readiness check

### DIFF
--- a/src/components/StoryboardView.tsx
+++ b/src/components/StoryboardView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -26,6 +26,9 @@ import {
   FileText,
   Lock,
   Unlock,
+  ListChecks,
+  CheckCircle2,
+  AlertTriangle,
 } from "lucide-react";
 import { useAppStore } from "../stores/appStore";
 import { useToastStore } from "../stores/toastStore";
@@ -35,6 +38,12 @@ import { exportStoryboardToWord } from "../utils/exportToWord";
 import { ExportWordButton } from "./ExportWordButton";
 import type { Sketch, SketchSummary } from "../types/sketch";
 import type { PreviewSlide } from "./SketchPreview";
+import {
+  buildReadinessAiPrompt,
+  computeStoryboardReadiness,
+  storyboardSketchPaths,
+  type StoryboardReadiness,
+} from "../utils/storyboardReadiness";
 
 interface MonitorInfo {
   id: number;
@@ -72,6 +81,7 @@ export function StoryboardView() {
 
   // Cache of full sketch data keyed by path
   const [sketchCache, setSketchCache] = useState<Map<string, Sketch>>(new Map());
+  const [sketchLoadErrors, setSketchLoadErrors] = useState<Map<string, string>>(new Map());
   const loadingRef = useRef<Set<string>>(new Set());
   const [collapsedItems, setCollapsedItems] = useState<Set<number>>(new Set());
   const [showMonitorPicker, setShowMonitorPicker] = useState(false);
@@ -82,8 +92,24 @@ export function StoryboardView() {
   const pendingDescRef = useRef<string | null>(null);
   const [availableMonitors, setAvailableMonitors] = useState<MonitorInfo[]>([]);
 
-  const sketchMap = new Map(sketches.map((s) => [s.path, s]));
+  const sketchMap = useMemo(() => new Map(sketches.map((s) => [s.path, s])), [sketches]);
   const storyboardLocked = activeStoryboard?.locked ?? false;
+  const storyboardPaths = useMemo(
+    () => activeStoryboard ? storyboardSketchPaths(activeStoryboard.items) : [],
+    [activeStoryboard],
+  );
+  const readiness = useMemo(() => computeStoryboardReadiness(
+    storyboardPaths.map((path) => {
+      const summary = sketchMap.get(path);
+      const sketch = sketchCache.get(path);
+        return {
+          path,
+          title: sketch?.title || summary?.title || path,
+          sketch,
+          loadError: sketchLoadErrors.get(path),
+        };
+      }),
+  ), [sketchCache, sketchLoadErrors, sketchMap, storyboardPaths]);
 
   // Reset the local description when switching storyboards.
   useEffect(() => {
@@ -137,16 +163,27 @@ export function StoryboardView() {
   // Eagerly load all referenced sketches
   useEffect(() => {
     if (!activeStoryboard) return;
-    for (const item of activeStoryboard.items) {
-      if (item.type === "sketch_ref" && !sketchCache.has(item.path) && !loadingRef.current.has(item.path)) {
-        loadingRef.current.add(item.path);
-        invoke<Sketch>("get_sketch", { relativePath: item.path })
-          .then((sketch) => setSketchCache((prev) => new Map(prev).set(item.path, sketch)))
-          .catch((err) => console.error("Failed to load sketch:", err))
-          .finally(() => loadingRef.current.delete(item.path));
+    for (const path of storyboardPaths) {
+      if (!sketchCache.has(path) && !loadingRef.current.has(path)) {
+        loadingRef.current.add(path);
+        invoke<Sketch>("get_sketch", { relativePath: path })
+          .then((sketch) => {
+            setSketchLoadErrors((prev) => {
+              if (!prev.has(path)) return prev;
+              const next = new Map(prev);
+              next.delete(path);
+              return next;
+            });
+            setSketchCache((prev) => new Map(prev).set(path, sketch));
+          })
+          .catch((err) => {
+            console.error("Failed to load sketch:", err);
+            setSketchLoadErrors((prev) => new Map(prev).set(path, err instanceof Error ? err.message : String(err)));
+          })
+          .finally(() => loadingRef.current.delete(path));
       }
     }
-  }, [activeStoryboard, sketchCache]);
+  }, [activeStoryboard, sketchCache, storyboardPaths]);
 
   /** Build typed slides for preview: storyboard title → (sketch title → sketch rows)... */
   const buildPreviewSlides = useCallback((): PreviewSlide[] => {
@@ -217,6 +254,14 @@ export function StoryboardView() {
       console.error("[StoryboardView] Failed to list monitors:", e);
     }
   }, [launchPreviewOnMonitor]);
+
+  const handleFixReadinessWithAi = useCallback(() => {
+    if (!activeStoryboard || storyboardLocked) return;
+    sendChatPrompt(
+      buildReadinessAiPrompt(activeStoryboard, activeStoryboardPath, readiness),
+      { silent: true, agent: "editor" },
+    );
+  }, [activeStoryboard, activeStoryboardPath, readiness, sendChatPrompt, storyboardLocked]);
 
   // DnD
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
@@ -434,6 +479,12 @@ export function StoryboardView() {
         </div>
         )}
 
+        <ReadinessCheckCard
+          readiness={readiness}
+          canFix={!storyboardLocked && !readiness.ready && readiness.loadedSketches > 0}
+          onFixWithAi={handleFixReadinessWithAi}
+        />
+
         {/* Items */}
         {activeStoryboard.items.length === 0 ? (
           <EmptyState
@@ -552,6 +603,112 @@ const stateLabels: Record<string, string> = {
   refined: "Refined",
   final: "Final",
 };
+
+function ReadinessCheckCard({
+  readiness,
+  canFix,
+  onFixWithAi,
+}: {
+  readiness: StoryboardReadiness;
+  canFix: boolean;
+  onFixWithAi: () => void;
+}) {
+  const statusColor = readiness.ready ? "rgb(var(--color-success))" : "rgb(var(--color-warning))";
+  const statusBg = readiness.ready ? "rgb(var(--color-success) / 0.1)" : "rgb(var(--color-warning) / 0.1)";
+  const incompleteLabel = readiness.incompleteRows === 1 ? "incomplete row" : "incomplete rows";
+
+  return (
+    <section className="mb-8 rounded-2xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-alt))]/60 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div
+            className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl"
+            style={{ backgroundColor: statusBg, color: statusColor }}
+          >
+            {readiness.ready ? <CheckCircle2 className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-semibold text-[rgb(var(--color-text))]">Readiness Check</h2>
+              <span
+                className="rounded-full px-2 py-0.5 text-[10px] font-medium"
+                style={{ backgroundColor: statusBg, color: statusColor }}
+              >
+                {readiness.status}
+              </span>
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-[rgb(var(--color-text-secondary))]">
+              {readiness.totalRows} {readiness.totalRows === 1 ? "row" : "rows"} scanned across {readiness.loadedSketches}/{readiness.totalSketches} loaded sketches.
+              {!readiness.ready && ` ${readiness.incompleteRows} ${incompleteLabel} need attention before recording.`}
+            </p>
+          </div>
+        </div>
+
+        {canFix && (
+          <button
+            onClick={onFixWithAi}
+            className="shrink-0 flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-[rgb(var(--color-accent))] hover:bg-[rgb(var(--color-accent))]/10 transition-colors"
+            title="Ask AI to fix readiness gaps without touching locked rows"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            Fix gaps
+          </button>
+        )}
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <ReadinessMetric label="Missing timing" value={readiness.missingTiming} />
+        <ReadinessMetric label="Missing narration" value={readiness.missingNarration} />
+        <ReadinessMetric label="Missing actions" value={readiness.missingDemoActions} />
+        <ReadinessMetric label="Missing visuals" value={readiness.missingVisuals} />
+      </div>
+
+      {readiness.nextSteps.length > 0 && (
+        <div className="mt-4 rounded-xl border border-[rgb(var(--color-border))]/70 bg-[rgb(var(--color-surface))]/60 p-3">
+          <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-[rgb(var(--color-text))]">
+            <ListChecks className="h-3.5 w-3.5 text-[rgb(var(--color-accent))]" />
+            Next steps
+          </div>
+          <ul className="space-y-1 text-xs leading-relaxed text-[rgb(var(--color-text-secondary))]">
+            {readiness.nextSteps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {readiness.incompleteSketches.length > 0 && (
+        <details className="mt-3">
+          <summary className="cursor-pointer text-xs font-medium text-[rgb(var(--color-text-secondary))] hover:text-[rgb(var(--color-text))] transition-colors">
+            {readiness.incompleteSketches.length} {readiness.incompleteSketches.length === 1 ? "sketch looks" : "sketches look"} incomplete
+          </summary>
+          <div className="mt-2 space-y-2">
+            {readiness.incompleteSketches.map((sketch) => (
+              <div key={sketch.path} className="rounded-lg border border-[rgb(var(--color-border))]/70 bg-[rgb(var(--color-surface))]/50 px-3 py-2">
+                <div className="truncate text-xs font-medium text-[rgb(var(--color-text))]">{sketch.title}</div>
+                <div className="mt-1 text-[11px] leading-relaxed text-[rgb(var(--color-text-secondary))]">
+                  {sketch.issues.join(" - ")}
+                </div>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function ReadinessMetric({ label, value }: { label: string; value: number }) {
+  const hasIssue = value > 0;
+  return (
+    <div className="rounded-xl border border-[rgb(var(--color-border))]/70 bg-[rgb(var(--color-surface))]/60 px-3 py-2">
+      <div className={`text-lg font-semibold ${hasIssue ? "text-[rgb(var(--color-warning))]" : "text-[rgb(var(--color-success))]"}`}>
+        {value}
+      </div>
+      <div className="text-[11px] text-[rgb(var(--color-text-secondary))]">{label}</div>
+    </div>
+  );
+}
 
 function ExpandableSketchCard({
   sketch,

--- a/src/test/storyboardReadiness.test.ts
+++ b/src/test/storyboardReadiness.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReadinessAiPrompt,
+  computeStoryboardReadiness,
+  storyboardSketchPaths,
+} from "../utils/storyboardReadiness";
+import type { Sketch, Storyboard } from "../types/sketch";
+
+function sketch(rows: Sketch["rows"], locked = false): Sketch {
+  return {
+    title: "Setup",
+    locked,
+    description: "",
+    rows,
+    state: "draft",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("storyboard readiness", () => {
+  it("counts gaps across sketch rows", () => {
+    const readiness = computeStoryboardReadiness([
+      {
+        path: "setup.sk",
+        title: "Setup",
+        sketch: sketch([
+          {
+            time: "0:10",
+            narrative: "Open with the setup.",
+            demo_actions: "Open the dashboard.",
+            screenshot: "screenshots/setup.png",
+          },
+          {
+            locked: true,
+            time: "",
+            narrative: "",
+            demo_actions: "Click Create.",
+            screenshot: null,
+            visual: null,
+          },
+        ]),
+      },
+    ]);
+
+    expect(readiness.status).toBe("Needs Work");
+    expect(readiness.totalRows).toBe(2);
+    expect(readiness.incompleteRows).toBe(1);
+    expect(readiness.lockedRows).toBe(1);
+    expect(readiness.missingTiming).toBe(1);
+    expect(readiness.missingNarration).toBe(1);
+    expect(readiness.missingDemoActions).toBe(0);
+    expect(readiness.missingVisuals).toBe(1);
+    expect(readiness.incompleteSketches[0]?.issues).toContain("1 incomplete row");
+  });
+
+  it("marks complete storyboards as ready", () => {
+    const readiness = computeStoryboardReadiness([
+      {
+        path: "demo.sk",
+        title: "Demo",
+        sketch: sketch([
+          {
+            time: "0:20",
+            narrative: "Show the key workflow.",
+            demo_actions: "Run the demo.",
+            screenshot: null,
+            visual: ".cutready/visuals/demo.json",
+          },
+        ]),
+      },
+    ]);
+
+    expect(readiness.ready).toBe(true);
+    expect(readiness.status).toBe("Ready");
+    expect(readiness.nextSteps[0]).toContain("Start recording");
+  });
+
+  it("deduplicates sketch paths from legacy sections", () => {
+    expect(storyboardSketchPaths([
+      { type: "sketch_ref", path: "intro.sk" },
+      { type: "section", title: "Part 1", sketches: ["intro.sk", "demo.sk"] },
+    ])).toEqual(["intro.sk", "demo.sk"]);
+  });
+
+  it("builds an AI fix prompt that protects locked rows", () => {
+    const storyboard: Storyboard = {
+      title: "Launch Demo",
+      description: "",
+      items: [{ type: "sketch_ref", path: "setup.sk" }],
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const readiness = computeStoryboardReadiness([
+      {
+        path: "setup.sk",
+        title: "Setup",
+        sketch: sketch([
+          {
+            time: "",
+            narrative: "",
+            demo_actions: "",
+            screenshot: null,
+          },
+        ]),
+      },
+    ]);
+
+    const prompt = buildReadinessAiPrompt(storyboard, "launch.sb", readiness);
+
+    expect(prompt).toContain("Launch Demo");
+    expect(prompt).toContain("Do not touch any locked sketch, locked row, or locked cell");
+    expect(prompt).toContain("missing time");
+    expect(prompt).toContain("setup.sk");
+  });
+
+  it("surfaces all next steps and failed sketch loads", () => {
+    const readiness = computeStoryboardReadiness([
+      { path: "missing.sk", title: "Missing", loadError: "not found" },
+      { path: "empty.sk", title: "Empty", sketch: sketch([]) },
+      {
+        path: "gaps.sk",
+        title: "Gaps",
+        sketch: sketch([
+          {
+            time: "",
+            narrative: "",
+            demo_actions: "",
+            screenshot: null,
+          },
+        ]),
+      },
+    ]);
+
+    expect(readiness.failedSketches).toBe(1);
+    expect(readiness.incompleteSketches[0]?.issues[0]).toContain("Sketch could not be loaded");
+    expect(readiness.nextSteps).toEqual([
+      "Fix missing or unreadable sketch references.",
+      "Add planning rows to empty sketches.",
+      "Add time estimates to rows without timing.",
+      "Write narration for rows without voiceover.",
+      "Clarify demo actions for rows that are vague or empty.",
+      "Attach screenshots or create visuals for rows with no visual reference.",
+    ]);
+  });
+});

--- a/src/test/storyboardView.test.tsx
+++ b/src/test/storyboardView.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StoryboardView } from "../components/StoryboardView";
 import { useAppStore } from "../stores/appStore";
-import type { Storyboard } from "../types/sketch";
+import type { Sketch, Storyboard } from "../types/sketch";
 
 const mockInvoke = vi.fn();
 
@@ -20,6 +20,32 @@ function activeStoryboard(description = "Original description", locked = false):
     description,
     locked,
     items: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function activeStoryboardWithSketches(): Storyboard {
+  return {
+    ...activeStoryboard("Storyboard with gaps"),
+    items: [{ type: "sketch_ref", path: "setup.sk" }],
+  };
+}
+
+function incompleteSketch(): Sketch {
+  return {
+    title: "Setup",
+    description: "",
+    rows: [
+      {
+        time: "",
+        narrative: "",
+        demo_actions: "Open the dashboard.",
+        screenshot: null,
+        visual: null,
+      },
+    ],
+    state: "draft",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
   };
@@ -131,5 +157,77 @@ describe("StoryboardView", () => {
       relativePath: "demo.sb",
       locked: false,
     });
+  });
+
+  it("shows readiness gaps and queues an AI fix prompt", async () => {
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === "get_sketch") return Promise.resolve(incompleteSketch());
+      return Promise.resolve([]);
+    });
+    useAppStore.setState({
+      activeStoryboard: activeStoryboardWithSketches(),
+      sketches: [{
+        path: "setup.sk",
+        title: "Setup",
+        state: "draft",
+        row_count: 1,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      }],
+      pendingChatPrompt: null,
+    });
+
+    render(<StoryboardView />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Readiness Check")).toBeInTheDocument();
+    expect(screen.getByText("Needs Work")).toBeInTheDocument();
+    expect(screen.getByText("Missing timing").previousElementSibling).toHaveTextContent("1");
+    expect(screen.getByText("Missing narration").previousElementSibling).toHaveTextContent("1");
+    expect(screen.getByText("Missing visuals").previousElementSibling).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByTitle("Ask AI to fix readiness gaps without touching locked rows"));
+
+    const queued = useAppStore.getState().pendingChatPrompt;
+    expect(queued?.agent).toBe("editor");
+    expect(queued?.silent).toBe(true);
+    expect(queued?.text).toContain("Do not touch any locked sketch, locked row, or locked cell");
+    expect(queued?.text).toContain("setup.sk");
+  });
+
+  it("surfaces sketch load failures in the readiness check", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mockInvoke.mockImplementation((command: string) => {
+        if (command === "get_sketch") return Promise.reject(new Error("missing sketch"));
+        return Promise.resolve([]);
+      });
+      useAppStore.setState({
+        activeStoryboard: activeStoryboardWithSketches(),
+        sketches: [{
+          path: "setup.sk",
+          title: "Setup",
+          state: "draft",
+          row_count: 1,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+        pendingChatPrompt: null,
+      });
+
+      render(<StoryboardView />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      fireEvent.click(screen.getByText("1 sketch looks incomplete"));
+
+      expect(screen.getByText(/Sketch could not be loaded: missing sketch/)).toBeInTheDocument();
+      expect(screen.getByText("Fix missing or unreadable sketch references.")).toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/src/utils/storyboardReadiness.ts
+++ b/src/utils/storyboardReadiness.ts
@@ -1,0 +1,203 @@
+import type { Sketch, Storyboard, StoryboardItem } from "../types/sketch";
+
+export interface ReadinessSketchInput {
+  path: string;
+  title: string;
+  sketch?: Sketch | null;
+  loadError?: string | null;
+}
+
+export interface IncompleteSketchSummary {
+  path: string;
+  title: string;
+  issues: string[];
+}
+
+export interface StoryboardReadiness {
+  ready: boolean;
+  status: "Ready" | "Needs Work";
+  totalSketches: number;
+  loadedSketches: number;
+  totalRows: number;
+  incompleteRows: number;
+  lockedRows: number;
+  missingTiming: number;
+  missingNarration: number;
+  missingDemoActions: number;
+  missingVisuals: number;
+  emptySketches: number;
+  unloadedSketches: number;
+  failedSketches: number;
+  incompleteSketches: IncompleteSketchSummary[];
+  nextSteps: string[];
+}
+
+const blank = (value: string | null | undefined) => !value || value.trim().length === 0;
+
+export function storyboardSketchPaths(items: StoryboardItem[]): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  const add = (path: string) => {
+    if (seen.has(path)) return;
+    seen.add(path);
+    paths.push(path);
+  };
+
+  for (const item of items) {
+    if (item.type === "sketch_ref") {
+      add(item.path);
+    } else {
+      item.sketches.forEach(add);
+    }
+  }
+
+  return paths;
+}
+
+export function buildReadinessAiPrompt(storyboard: Storyboard, storyboardPath: string | null, readiness: StoryboardReadiness): string {
+  const incomplete = readiness.incompleteSketches
+    .map((sketch) => `- ${sketch.title} (${sketch.path}): ${sketch.issues.join("; ")}`)
+    .join("\n");
+
+  return [
+    `Run a Readiness Check fix pass for the storyboard "${storyboard.title}"${storyboardPath ? ` at "${storyboardPath}"` : ""}.`,
+    "Use read_storyboard and read_sketch to inspect the current storyboard and every referenced sketch before editing.",
+    "Fill gaps that block recording: missing time, missing narrative, missing demo actions, and rows missing both screenshot and visual.",
+    "Do not touch any locked sketch, locked row, or locked cell. Preserve existing user content unless it is clearly a placeholder.",
+    "For rows without screenshot or visual, prefer creating an appropriate visual/design plan; do not invent a screenshot path.",
+    "Apply safe changes with update_planning_row or the visual tools only, then summarize what changed and what still needs human input.",
+    "",
+    `Current status: ${readiness.status}. Total rows: ${readiness.totalRows}. Incomplete rows: ${readiness.incompleteRows}. Locked rows: ${readiness.lockedRows}.`,
+    incomplete ? `Known gaps:\n${incomplete}` : "Known gaps: none from the local check.",
+  ].join("\n");
+}
+
+export function computeStoryboardReadiness(sketches: ReadinessSketchInput[]): StoryboardReadiness {
+  const readiness: StoryboardReadiness = {
+    ready: false,
+    status: "Needs Work",
+    totalSketches: sketches.length,
+    loadedSketches: 0,
+    totalRows: 0,
+    incompleteRows: 0,
+    lockedRows: 0,
+    missingTiming: 0,
+    missingNarration: 0,
+    missingDemoActions: 0,
+    missingVisuals: 0,
+    emptySketches: 0,
+    unloadedSketches: 0,
+    failedSketches: 0,
+    incompleteSketches: [],
+    nextSteps: [],
+  };
+
+  for (const item of sketches) {
+    const sketch = item.sketch;
+    const issues: string[] = [];
+
+    if (item.loadError) {
+      readiness.failedSketches += 1;
+      readiness.incompleteSketches.push({
+        path: item.path,
+        title: item.title,
+        issues: [`Sketch could not be loaded: ${item.loadError}`],
+      });
+      continue;
+    }
+
+    if (!sketch) {
+      readiness.unloadedSketches += 1;
+      readiness.incompleteSketches.push({
+        path: item.path,
+        title: item.title,
+        issues: ["Waiting for sketch data"],
+      });
+      continue;
+    }
+
+    readiness.loadedSketches += 1;
+    if (sketch.rows.length === 0) {
+      readiness.emptySketches += 1;
+      issues.push("No planning rows");
+    }
+
+    let sketchIncompleteRows = 0;
+    let sketchMissingTiming = 0;
+    let sketchMissingNarration = 0;
+    let sketchMissingActions = 0;
+    let sketchMissingVisuals = 0;
+
+    for (const row of sketch.rows) {
+      readiness.totalRows += 1;
+      if (row.locked || sketch.locked) readiness.lockedRows += 1;
+
+      const missingTiming = blank(row.time);
+      const missingNarration = blank(row.narrative);
+      const missingActions = blank(row.demo_actions);
+      const missingVisual = blank(row.screenshot) && blank(row.visual);
+
+      if (missingTiming) {
+        readiness.missingTiming += 1;
+        sketchMissingTiming += 1;
+      }
+      if (missingNarration) {
+        readiness.missingNarration += 1;
+        sketchMissingNarration += 1;
+      }
+      if (missingActions) {
+        readiness.missingDemoActions += 1;
+        sketchMissingActions += 1;
+      }
+      if (missingVisual) {
+        readiness.missingVisuals += 1;
+        sketchMissingVisuals += 1;
+      }
+      if (missingTiming || missingNarration || missingActions || missingVisual) {
+        readiness.incompleteRows += 1;
+        sketchIncompleteRows += 1;
+      }
+    }
+
+    if (sketchIncompleteRows > 0) issues.push(`${sketchIncompleteRows} incomplete ${sketchIncompleteRows === 1 ? "row" : "rows"}`);
+    if (sketchMissingTiming > 0) issues.push(`${sketchMissingTiming} missing timing`);
+    if (sketchMissingNarration > 0) issues.push(`${sketchMissingNarration} missing narration`);
+    if (sketchMissingActions > 0) issues.push(`${sketchMissingActions} missing demo actions`);
+    if (sketchMissingVisuals > 0) issues.push(`${sketchMissingVisuals} missing screenshot or visual`);
+
+    if (issues.length > 0) {
+      readiness.incompleteSketches.push({
+        path: item.path,
+        title: sketch.title || item.title,
+        issues,
+      });
+    }
+  }
+
+  readiness.ready = readiness.totalSketches > 0
+    && readiness.loadedSketches === readiness.totalSketches
+    && readiness.totalRows > 0
+    && readiness.emptySketches === 0
+    && readiness.failedSketches === 0
+    && readiness.incompleteRows === 0;
+  readiness.status = readiness.ready ? "Ready" : "Needs Work";
+  readiness.nextSteps = buildNextSteps(readiness);
+
+  return readiness;
+}
+
+function buildNextSteps(readiness: StoryboardReadiness): string[] {
+  if (readiness.ready) {
+    return ["Start recording. Every row has timing, narration, demo actions, and a screenshot or visual."];
+  }
+
+  const steps: string[] = [];
+  if (readiness.failedSketches > 0) steps.push("Fix missing or unreadable sketch references.");
+  if (readiness.unloadedSketches > 0) steps.push("Wait for all sketches to load, then re-run the check.");
+  if (readiness.emptySketches > 0) steps.push("Add planning rows to empty sketches.");
+  if (readiness.missingTiming > 0) steps.push("Add time estimates to rows without timing.");
+  if (readiness.missingNarration > 0) steps.push("Write narration for rows without voiceover.");
+  if (readiness.missingDemoActions > 0) steps.push("Clarify demo actions for rows that are vague or empty.");
+  if (readiness.missingVisuals > 0) steps.push("Attach screenshots or create visuals for rows with no visual reference.");
+  return steps;
+}


### PR DESCRIPTION
## Summary
- Add a storyboard Readiness Check card with Ready / Needs Work status
- Summarize total rows, missing timing, narration, demo actions, and screenshot/visual gaps
- Flag incomplete or unreadable sketches with actionable next steps
- Add an AI fix prompt that asks the Editor agent to fill gaps without touching locked sketches, rows, or cells

## Source of truth
Martin Woodward's latest email requested a storyboard readiness check before recording.

## Validation
- npm run build
- npm run test
- npx vitest run src/test/storyboardReadiness.test.ts src/test/storyboardView.test.tsx && npx tsc --noEmit

## Review
- Rubber-duck multi-model review completed with claude-sonnet-4.6 and gpt-5.4; findings addressed before commit.