### PR TITLE
fix(layout): allow panels to resize more freely

### DIFF
--- a/src/components/StoryboardPanel.tsx
+++ b/src/components/StoryboardPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useAppStore } from "../stores/appStore";
 import { StoryboardView } from "./StoryboardView";
 import { SketchForm } from "./SketchForm";
@@ -41,6 +41,7 @@ export function StoryboardPanel() {
   const activeEditorReloadKey = activeTab?.path === editorReloadPath ? editorReloadKey : 0;
 
   const [splitWidth, setSplitWidth] = useState<number | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const secondaryOnLeft = sidebarPosition === "right";
 
   const handleSecondaryResize = useCallback(
@@ -53,7 +54,9 @@ export function StoryboardPanel() {
 
   const handleSplitResize = useCallback(
     (delta: number) => {
-      setSplitWidth((w) => Math.max(200, (w ?? 400) - delta));
+      const availableWidth = panelRef.current?.clientWidth ?? window.innerWidth;
+      const maxSplitWidth = Math.max(180, availableWidth - 280);
+      setSplitWidth((w) => Math.min(maxSplitWidth, Math.max(180, (w ?? availableWidth / 2) - delta)));
     },
     [],
   );
@@ -88,7 +91,7 @@ export function StoryboardPanel() {
         </div>
 
         {/* Content row — primary + optional split */}
-        <div className="flex-1 flex min-h-0">
+        <div className="flex-1 flex min-h-0" ref={panelRef}>
           {/* Primary pane */}
           <div className="flex-1 flex flex-col min-w-0" onMouseDown={() => setActiveEditorGroup("main")}>
             {isHistoryTab ? (

--- a/src/components/presentation/SlidesView.tsx
+++ b/src/components/presentation/SlidesView.tsx
@@ -28,6 +28,15 @@ const VisualCell = lazy(() => import("../VisualCell"));
 
 const PREFS_KEY = "cutready:preview";
 
+function clampPreviewPanelWidth(width: number) {
+  const viewportWidth = typeof window === "undefined" ? 1440 : window.innerWidth;
+  const maxWidth = Math.max(
+    180,
+    Math.min(Math.max(720, viewportWidth - 360), Math.max(180, viewportWidth - 280)),
+  );
+  return Math.min(maxWidth, Math.max(180, width));
+}
+
 function loadPrefs(): {
   panelSide: "left" | "right";
   panelWidth: number;
@@ -39,7 +48,7 @@ function loadPrefs(): {
       const parsed = JSON.parse(raw);
       return {
         panelSide: parsed.panelSide === "right" ? "right" : "left",
-        panelWidth: Math.min(600, Math.max(200, parsed.panelWidth ?? 320)),
+        panelWidth: clampPreviewPanelWidth(parsed.panelWidth ?? 320),
         panelVisible: parsed.panelVisible !== false,
       };
     }
@@ -115,7 +124,7 @@ export function SlidesView({
     (delta: number) => {
       setPanelWidth((w) => {
         const adjusted = panelSide === "left" ? w + delta : w - delta;
-        return Math.min(600, Math.max(200, adjusted));
+        return clampPreviewPanelWidth(adjusted);
       });
     },
     [panelSide]

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -681,6 +681,38 @@ function saveLayout(partial: Record<string, unknown>) {
 
 const savedLayout = loadLayout();
 
+function viewportWidth() {
+  return typeof window === "undefined" ? 1440 : window.innerWidth;
+}
+
+function viewportHeight() {
+  return typeof window === "undefined" ? 900 : window.innerHeight;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function maxWidthWithRemainder(min: number, desired: number, minRemainder: number) {
+  return Math.max(min, Math.min(Math.max(min, desired), Math.max(min, viewportWidth() - minRemainder)));
+}
+
+function maxHeightWithRemainder(min: number, desired: number, minRemainder: number) {
+  return Math.max(min, Math.min(Math.max(min, desired), Math.max(min, viewportHeight() - minRemainder)));
+}
+
+function clampSidebarWidth(width: number) {
+  return clamp(width, 160, maxWidthWithRemainder(160, Math.max(400, viewportWidth() - 420), 320));
+}
+
+function clampSecondaryWidth(width: number) {
+  return clamp(width, 260, maxWidthWithRemainder(260, Math.max(720, viewportWidth() - 360), 320));
+}
+
+function clampOutputHeight(height: number) {
+  return clamp(height, 72, maxHeightWithRemainder(72, Math.max(500, viewportHeight() - 220), 160));
+}
+
 export const useAppStore = create<AppStoreState>((set, get) => ({
   view: "home",
   currentProject: null,
@@ -689,11 +721,11 @@ export const useAppStore = create<AppStoreState>((set, get) => ({
   isMultiProject: false,
   loading: false,
   error: null,
-  sidebarWidth: savedLayout.sidebarWidth ?? 240,
+  sidebarWidth: clampSidebarWidth(savedLayout.sidebarWidth ?? 240),
   sidebarVisible: savedLayout.sidebarVisible ?? true,
   outputVisible: savedLayout.outputVisible ?? false,
-  outputHeight: savedLayout.outputHeight ?? 200,
-  secondaryWidth: savedLayout.secondaryWidth ?? 420,
+  outputHeight: clampOutputHeight(savedLayout.outputHeight ?? 200),
+  secondaryWidth: clampSecondaryWidth(savedLayout.secondaryWidth ?? 420),
   sidebarPosition: savedLayout.sidebarPosition ?? "left",
 
   openTabs: [],
@@ -767,7 +799,7 @@ export const useAppStore = create<AppStoreState>((set, get) => ({
   clearError: () => set({ error: null }),
   setView: (view) => set({ view }),
   setSidebarWidth: (width) => {
-    const w = Math.min(400, Math.max(180, width));
+    const w = clampSidebarWidth(width);
     set({ sidebarWidth: w });
     saveLayout({ sidebarWidth: w });
   },
@@ -780,13 +812,13 @@ export const useAppStore = create<AppStoreState>((set, get) => ({
     return { outputVisible: !s.outputVisible };
   }),
   setOutputHeight: (height) => {
-    const h = Math.min(500, Math.max(80, height));
+    const h = clampOutputHeight(height);
     set({ outputHeight: h });
     saveLayout({ outputHeight: h });
   },
   setSecondaryWidth: (width) => {
     const next = typeof width === "function" ? width(get().secondaryWidth) : width;
-    const w = Math.min(720, Math.max(320, next));
+    const w = clampSecondaryWidth(next);
     set({ secondaryWidth: w });
     saveLayout({ secondaryWidth: w });
   },


### PR DESCRIPTION
## Summary
- Loosen app-level resize bounds for the primary sidebar, secondary/chat panel, and output panel
- Allow split preview/editor panes to use more of the workspace while preserving a usable primary pane
- Remove the hard 600px cap from the presentation preview side panel with responsive viewport-aware bounds

## Validation
- `npx tsc --noEmit`
- Rubber-duck review pass found no blocking issues