### PR TITLE
feat(agent): persist agentive run state

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -60,8 +60,9 @@ dependencies = [
 
 [[package]]
 name = "agentive"
-version = "0.1.0"
-source = "git+https://github.com/sethjuarez/agentive.git#8be3d6514f6b24ca756beee032ea1c9ef2e6cad5"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4179ee996e7d083348b558730746ecec242b6ea6529295520cd5f05d679777af"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -77,6 +78,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "urlencoding",
  "uuid",
 ]
@@ -1295,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "cutready"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "agentive",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,7 +57,7 @@ tauri-plugin-opener = "2.5.3"
 tauri-plugin-stronghold = "2"
 
 # Shared agentic substrate
-agentive = { git = "https://github.com/sethjuarez/agentive.git" }
+agentive = { version = "0.2.1", features = ["tracing"] }
 
 # Vendor OpenSSL on macOS to support cross-compilation (ARM → Intel)
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -249,8 +249,52 @@ pub async fn agent_chat_with_tools(
 
     let provider = llm::build_provider(&llm_config, reported_context);
     let budget_chars = provider.context_budget_chars();
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let agent_state = match crate::engine::agent_state::AgentStateStore::for_project(
+        &project_root,
+        run_id.clone(),
+    ) {
+        Ok(store) => {
+            let insert_result = store.insert_run(
+                None,
+                &provider_name,
+                &model,
+                serde_json::json!({
+                    "messages": message_count,
+                    "chars": message_chars,
+                    "budget_chars": budget_chars,
+                    "reported_context": reported_context,
+                    "vision_enabled": vision.enabled,
+                    "web_search_enabled": web_access.search_enabled,
+                    "agent_prompts": prompts.len(),
+                }),
+            );
+            match insert_result {
+                Ok(()) => Some(store),
+                Err(err) => {
+                    log::warn!("[agent_chat_with_tools] agent state disabled: {err}");
+                    crate::util::trace::emit(
+                        "agent_state_disabled",
+                        "agent",
+                        serde_json::json!({ "run_id": &run_id, "error": err }),
+                    );
+                    None
+                }
+            }
+        }
+        Err(err) => {
+            log::warn!("[agent_chat_with_tools] agent state disabled: {err}");
+            crate::util::trace::emit(
+                "agent_state_disabled",
+                "agent",
+                serde_json::json!({ "run_id": &run_id, "error": err }),
+            );
+            None
+        }
+    };
     log::info!(
-        "[agent_chat_with_tools] start provider={} model={} messages={} chars={} budget={}chars reported_context={:?} vision={} web_search={} prompts={}",
+        "[agent_chat_with_tools] start run_id={} provider={} model={} messages={} chars={} budget={}chars reported_context={:?} vision={} web_search={} prompts={}",
+        run_id,
         provider_name,
         model,
         message_count,
@@ -267,6 +311,7 @@ pub async fn agent_chat_with_tools(
         serde_json::json!({
             "provider": provider_name,
             "model": model,
+            "run_id": &run_id,
             "messages": message_count,
             "chars": message_chars,
             "budget_chars": budget_chars,
@@ -286,6 +331,8 @@ pub async fn agent_chat_with_tools(
         &steering,
         &vision,
         &web_access,
+        Some(run_id.clone()),
+        agent_state.clone(),
         move |event: AgentEvent| {
             let _ = emit_handle.emit("agent-event", &event);
         },
@@ -309,12 +356,18 @@ pub async fn agent_chat_with_tools(
                 serde_json::json!({
                     "provider": provider_name,
                     "model": model,
+                    "run_id": &run_id,
                     "elapsed_ms": elapsed_ms,
                     "response_chars": result.response.len(),
                     "total_messages": result.messages.len(),
                     "total_tokens": result.total_usage.total_tokens,
                 }),
             );
+            if let Some(agent_state) = &agent_state {
+                if let Err(err) = agent_state.finish_run("completed") {
+                    log::warn!("[agent_chat_with_tools] failed to finish agent state run: {err}");
+                }
+            }
             result
         }
         Err(err) => {
@@ -332,10 +385,18 @@ pub async fn agent_chat_with_tools(
                 serde_json::json!({
                     "provider": provider_name,
                     "model": model,
+                    "run_id": &run_id,
                     "elapsed_ms": elapsed_ms,
                     "error": err,
                 }),
             );
+            if let Some(agent_state) = &agent_state {
+                if let Err(state_err) = agent_state.finish_run("failed") {
+                    log::warn!(
+                        "[agent_chat_with_tools] failed to mark agent state run failed: {state_err}"
+                    );
+                }
+            }
             return Err(err);
         }
     };

--- a/src-tauri/src/engine/agent/runner.rs
+++ b/src-tauri/src/engine/agent/runner.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 
 use crate::engine::agent::llm::ChatMessage;
 use crate::engine::agent::tools;
+use crate::engine::agent_state::AgentStateStore;
 use crate::engine::project;
 
 /// Maximum tool-call rounds to prevent infinite loops.
@@ -93,6 +94,8 @@ pub async fn run(
     steering: &agentive::Steering,
     vision: &VisionConfig,
     web_access: &WebAccessConfig,
+    run_id: Option<String>,
+    agent_state: Option<AgentStateStore>,
     emit: impl Fn(AgentEvent) + Send + Sync + 'static,
 ) -> Result<agentive::RunnerResult, String> {
     let emit = Arc::new(emit);
@@ -105,6 +108,8 @@ pub async fn run(
         0,
         vision,
         web_access,
+        run_id,
+        agent_state,
         emit,
     )
     .await
@@ -121,6 +126,8 @@ fn run_inner<'a>(
     depth: usize,
     vision: &'a VisionConfig,
     web_access: &'a WebAccessConfig,
+    run_id: Option<String>,
+    agent_state: Option<AgentStateStore>,
     emit: Arc<dyn Fn(AgentEvent) + Send + Sync + 'static>,
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = Result<agentive::RunnerResult, String>> + Send + 'a>,
@@ -162,6 +169,13 @@ fn run_inner<'a>(
             sanitize_tool_results: true,
             compaction_provider: Some(provider.clone()),
             reference_resolver: Some(build_reference_resolver(project_root)),
+            run_id: run_id.clone(),
+            trajectory_sink: agent_state
+                .clone()
+                .map(|store| Arc::new(store) as Arc<dyn agentive::TrajectorySink>),
+            memory_promotion_hook: agent_state
+                .clone()
+                .map(|store| Arc::new(store) as Arc<dyn agentive::MemoryPromotionHook>),
             ..Default::default()
         };
 
@@ -271,6 +285,10 @@ fn run_inner<'a>(
                         }),
                     );
                 }
+                agentive::RunnerEvent::ResourceTouched { .. }
+                | agentive::RunnerEvent::VerificationRecorded { .. }
+                | agentive::RunnerEvent::MemoryPromotionSuggested { .. }
+                | agentive::RunnerEvent::MemoryPromotionCompleted { .. } => {}
                 agentive::RunnerEvent::Done { response, .. } => {
                     emit_events(AgentEvent::Done { response });
                 }
@@ -322,6 +340,7 @@ fn run_inner<'a>(
                     agentive::web::fetch_and_clean(url)
                         .await
                         .map(agentive::ToolOutput::from)
+                        .map(|output| tools::decorate_tool_output(&tc.function.name, &args, output))
                 })
             } else if tool_call.function.name == "search_web" {
                 let tc = tool_call;
@@ -331,6 +350,7 @@ fn run_inner<'a>(
                     tools::exec_search_web(&args)
                         .await
                         .map(agentive::ToolOutput::from)
+                        .map(|output| tools::decorate_tool_output(&tc.function.name, &args, output))
                 })
             } else {
                 let output =
@@ -398,6 +418,13 @@ fn run_inner<'a>(
                     sanitize_tool_results: true,
                     compaction_provider: Some(provider.clone()),
                     reference_resolver: Some(build_reference_resolver(project_root)),
+                    run_id: run_id.clone(),
+                    trajectory_sink: agent_state
+                        .clone()
+                        .map(|store| Arc::new(store) as Arc<dyn agentive::TrajectorySink>),
+                    memory_promotion_hook: agent_state
+                        .clone()
+                        .map(|store| Arc::new(store) as Arc<dyn agentive::MemoryPromotionHook>),
                     ..Default::default()
                 };
 
@@ -444,6 +471,9 @@ fn run_inner<'a>(
                             agentive::web::fetch_and_clean(url)
                                 .await
                                 .map(agentive::ToolOutput::from)
+                                .map(|output| {
+                                    tools::decorate_tool_output(&tc.function.name, &args, output)
+                                })
                         })
                     } else if tool_call.function.name == "search_web" {
                         let tc = tool_call;
@@ -453,6 +483,9 @@ fn run_inner<'a>(
                             tools::exec_search_web(&args)
                                 .await
                                 .map(agentive::ToolOutput::from)
+                                .map(|output| {
+                                    tools::decorate_tool_output(&tc.function.name, &args, output)
+                                })
                         })
                     } else {
                         let output = tools::execute_tool(

--- a/src-tauri/src/engine/agent/tools.rs
+++ b/src-tauri/src/engine/agent/tools.rs
@@ -846,7 +846,132 @@ pub fn execute_tool(
         }),
     );
 
-    output
+    decorate_tool_output(&call.function.name, &args, output)
+}
+
+pub fn decorate_tool_output(
+    tool_name: &str,
+    args: &Value,
+    output: agentive::ToolOutput,
+) -> agentive::ToolOutput {
+    let mut resources = touched_resources_for_tool(tool_name, args);
+    let success = !is_tool_error(output.text());
+    let verification = agentive::VerificationResult::new(
+        format!("Tool {tool_name} completed"),
+        if success {
+            agentive::VerificationStatus::Passed
+        } else {
+            agentive::VerificationStatus::Failed
+        },
+        if success {
+            "Tool returned a non-error response"
+        } else {
+            "Tool returned an error response"
+        },
+    );
+
+    if resources.is_empty() && !matches!(tool_name, "delegate_to_agent") {
+        resources.push(agentive::TouchedResource::new(
+            "tool",
+            tool_name,
+            agentive::ResourceOperation::Execute,
+        ));
+    }
+
+    output.with_metadata(resources, vec![verification], Vec::new())
+}
+
+fn is_tool_error(result_text: &str) -> bool {
+    result_text.starts_with("Error:") || result_text.starts_with("Validation failed")
+}
+
+fn touched_resources_for_tool(tool_name: &str, args: &Value) -> Vec<agentive::TouchedResource> {
+    let mut resources = Vec::new();
+    let operation = match tool_name {
+        "read_note" | "read_sketch" | "read_storyboard" | "read_visual" => {
+            agentive::ResourceOperation::Read
+        }
+        "write_note" | "write_sketch" | "write_storyboard" | "write_visual" => {
+            agentive::ResourceOperation::Write
+        }
+        "create_visual" => agentive::ResourceOperation::Create,
+        "update_planning_row"
+        | "set_row_visual"
+        | "review_row_visual"
+        | "apply_row_visual_nudge"
+        | "apply_row_visual_command" => agentive::ResourceOperation::Update,
+        "fetch_url" => agentive::ResourceOperation::Read,
+        "search_web" => agentive::ResourceOperation::Search,
+        "list_project_files" => agentive::ResourceOperation::Inspect,
+        _ => agentive::ResourceOperation::Execute,
+    };
+
+    match tool_name {
+        "read_note" | "write_note" => push_path_resource(
+            &mut resources,
+            "note",
+            args.get("path").and_then(Value::as_str),
+            operation,
+            tool_name,
+        ),
+        "read_sketch" | "write_sketch" | "update_planning_row" | "set_row_visual" => {
+            push_path_resource(
+                &mut resources,
+                "sketch",
+                args.get("path").and_then(Value::as_str),
+                operation,
+                tool_name,
+            );
+        }
+        "read_storyboard" | "write_storyboard" => push_path_resource(
+            &mut resources,
+            "storyboard",
+            args.get("path").and_then(Value::as_str),
+            operation,
+            tool_name,
+        ),
+        "create_visual" | "read_visual" | "write_visual" => push_path_resource(
+            &mut resources,
+            "visual",
+            args.get("path")
+                .or_else(|| args.get("visual_path"))
+                .and_then(Value::as_str),
+            operation,
+            tool_name,
+        ),
+        "fetch_url" => push_path_resource(
+            &mut resources,
+            "url",
+            args.get("url").and_then(Value::as_str),
+            operation,
+            tool_name,
+        ),
+        "search_web" => push_path_resource(
+            &mut resources,
+            "web_search",
+            args.get("query").and_then(Value::as_str),
+            operation,
+            tool_name,
+        ),
+        _ => {}
+    }
+
+    resources
+}
+
+fn push_path_resource(
+    resources: &mut Vec<agentive::TouchedResource>,
+    kind: &str,
+    id: Option<&str>,
+    operation: agentive::ResourceOperation,
+    tool_name: &str,
+) {
+    if let Some(id) = id.map(str::trim).filter(|id| !id.is_empty()) {
+        resources.push(
+            agentive::TouchedResource::new(kind, id, operation)
+                .with_metadata("tool", tool_name.to_string()),
+        );
+    }
 }
 
 /// Extract a JSON object from a tool argument field. Handles three LLM behaviors:
@@ -4345,6 +4470,28 @@ mod tests {
     }
 
     #[test]
+    fn decorate_tool_output_adds_resource_and_verification_metadata() {
+        let output = decorate_tool_output(
+            "write_sketch",
+            &json!({ "path": "intro.sk" }),
+            agentive::ToolOutput::from("Saved sketch"),
+        );
+
+        assert_eq!(output.touched_resources().len(), 1);
+        assert_eq!(output.touched_resources()[0].kind, "sketch");
+        assert_eq!(output.touched_resources()[0].id, "intro.sk");
+        assert_eq!(
+            output.touched_resources()[0].operation,
+            agentive::ResourceOperation::Write
+        );
+        assert_eq!(output.verification_results().len(), 1);
+        assert_eq!(
+            output.verification_results()[0].status,
+            agentive::VerificationStatus::Passed
+        );
+    }
+
+    #[test]
     fn elucim_agent_operation_schema_advertises_catalog_operations() {
         let previous = std::env::var_os("CUTREADY_ELUCIM_BRIDGE");
         std::env::set_var("CUTREADY_ELUCIM_BRIDGE", "1");
@@ -4358,7 +4505,10 @@ mod tests {
         let tool = tools
             .iter()
             .map(|tool| serde_json::to_value(tool).unwrap())
-            .find(|tool| tool.pointer("/function/name").and_then(Value::as_str) == Some("elucim_agent_operation"))
+            .find(|tool| {
+                tool.pointer("/function/name").and_then(Value::as_str)
+                    == Some("elucim_agent_operation")
+            })
             .expect("elucim_agent_operation tool should be registered when bridge is enabled");
         let ops = tool
             .pointer("/function/parameters/properties/op/enum")

--- a/src-tauri/src/engine/agent_state.rs
+++ b/src-tauri/src/engine/agent_state.rs
@@ -1,0 +1,923 @@
+//! Project-scoped persistence for agent run state.
+//!
+//! Agentive owns the serializable observability/resumability models. CutReady
+//! owns where those records are stored, how they are retained, and how future UI
+//! surfaces will query them.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use agentive::{
+    Checkpoint, CheckpointStore, MemoryPromotionCandidate, MemoryPromotionHook,
+    MemoryPromotionOutcome, ResumeContext, TouchedResource, TrajectoryEvent, TrajectoryMetadata,
+    TrajectorySink, VerificationResult,
+};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+
+const AGENT_STATE_RELATIVE_PATH: &str = ".cutready/agent-state.db";
+const SCHEMA_VERSION: i32 = 1;
+const BUSY_TIMEOUT: Duration = Duration::from_millis(750);
+const MAX_COMPLETED_RUNS: usize = 100;
+const MAX_EVENTS_PER_RUN: usize = 1_000;
+const MAX_CHECKPOINTS_PER_RUN: usize = 25;
+const MAX_RESUME_CONTEXTS_PER_RUN: usize = 25;
+const MAX_TOUCHED_RESOURCES_PER_RUN: usize = 500;
+const MAX_VERIFICATION_RESULTS_PER_RUN: usize = 500;
+const MAX_MEMORY_PROMOTIONS_PER_RUN: usize = 200;
+
+#[derive(Debug, Clone)]
+pub struct AgentStateStore {
+    db_path: Arc<PathBuf>,
+    run_id: Arc<str>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AgentRunRecord {
+    pub run_id: String,
+    pub parent_run_id: Option<String>,
+    pub provider: String,
+    pub model: String,
+    pub status: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl AgentStateStore {
+    pub fn for_project(project_root: &Path, run_id: impl Into<String>) -> Result<Self, String> {
+        let db_path = project_root.join(AGENT_STATE_RELATIVE_PATH);
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Could not create CutReady agent state directory: {e}"))?;
+        }
+
+        let store = Self {
+            db_path: Arc::new(db_path),
+            run_id: Arc::from(run_id.into()),
+        };
+        store.initialize()?;
+        Ok(store)
+    }
+
+    #[cfg(test)]
+    fn for_database_path(db_path: PathBuf, run_id: impl Into<String>) -> Result<Self, String> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!("Could not create CutReady agent state test directory: {e}")
+            })?;
+        }
+        let store = Self {
+            db_path: Arc::new(db_path),
+            run_id: Arc::from(run_id.into()),
+        };
+        store.initialize()?;
+        Ok(store)
+    }
+
+    #[allow(dead_code)]
+    pub fn db_path(&self) -> &Path {
+        self.db_path.as_path()
+    }
+
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    pub fn initialize(&self) -> Result<(), String> {
+        let conn = self.connect()?;
+        initialize_schema(&conn)
+    }
+
+    pub fn insert_run(
+        &self,
+        parent_run_id: Option<&str>,
+        provider: &str,
+        model: &str,
+        metadata: serde_json::Value,
+    ) -> Result<(), String> {
+        let conn = self.connect()?;
+        let metadata_json = serde_json::to_string(&metadata).map_err(|e| e.to_string())?;
+        conn.execute(
+            "INSERT OR REPLACE INTO agent_runs
+                (run_id, parent_run_id, provider, model, status, started_at, completed_at, metadata_json)
+             VALUES (?1, ?2, ?3, ?4, 'running', ?5, NULL, ?6)",
+            params![
+                self.run_id(),
+                parent_run_id,
+                provider,
+                model,
+                Utc::now().to_rfc3339(),
+                metadata_json
+            ],
+        )
+        .map_err(|e| format!("Could not insert agent run: {e}"))?;
+        prune_completed_runs(&conn)?;
+        Ok(())
+    }
+
+    pub fn finish_run(&self, status: &str) -> Result<(), String> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE agent_runs SET status = ?2, completed_at = ?3 WHERE run_id = ?1",
+            params![self.run_id(), status, Utc::now().to_rfc3339()],
+        )
+        .map_err(|e| format!("Could not finish agent run: {e}"))?;
+        prune_completed_runs(&conn)?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn save_resume_context(&self, context: ResumeContext) -> Result<(), String> {
+        let conn = self.connect()?;
+        let context_json = serde_json::to_string(&context).map_err(|e| e.to_string())?;
+        conn.execute(
+            "INSERT INTO resume_contexts (run_id, checkpoint_id, created_at, context_json)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                self.run_id(),
+                context.checkpoint.id,
+                context.generated_at.to_rfc3339(),
+                context_json
+            ],
+        )
+        .map_err(|e| format!("Could not save resume context: {e}"))?;
+        prune_by_run_limit(
+            &conn,
+            "resume_contexts",
+            self.run_id(),
+            MAX_RESUME_CONTEXTS_PER_RUN,
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn record_touched_resource(&self, resource: &TouchedResource) -> Result<(), String> {
+        let conn = self.connect()?;
+        insert_touched_resource(&conn, self.run_id(), resource)
+    }
+
+    #[allow(dead_code)]
+    pub fn record_verification_result(&self, result: &VerificationResult) -> Result<(), String> {
+        let conn = self.connect()?;
+        insert_verification_result(&conn, self.run_id(), result)
+    }
+
+    pub fn record_memory_promotion_decision(
+        &self,
+        candidate: &MemoryPromotionCandidate,
+        outcome: Option<&MemoryPromotionOutcome>,
+    ) -> Result<(), String> {
+        let conn = self.connect()?;
+        insert_memory_promotion(&conn, self.run_id(), candidate, outcome)
+    }
+
+    #[allow(dead_code)]
+    pub fn get_run(&self, run_id: &str) -> Result<Option<AgentRunRecord>, String> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT run_id, parent_run_id, provider, model, status, started_at, completed_at
+             FROM agent_runs WHERE run_id = ?1",
+            params![run_id],
+            |row| {
+                Ok(AgentRunRecord {
+                    run_id: row.get(0)?,
+                    parent_run_id: row.get(1)?,
+                    provider: row.get(2)?,
+                    model: row.get(3)?,
+                    status: row.get(4)?,
+                    started_at: parse_rfc3339_row(row.get::<_, String>(5)?, 5)?,
+                    completed_at: row
+                        .get::<_, Option<String>>(6)?
+                        .map(|value| parse_rfc3339_row(value, 6))
+                        .transpose()?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|e| format!("Could not read agent run: {e}"))
+    }
+
+    #[allow(dead_code)]
+    pub fn trajectory_event_count(&self, run_id: &str) -> Result<usize, String> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT COUNT(*) FROM trajectory_events WHERE run_id = ?1",
+            params![run_id],
+            |row| row.get::<_, usize>(0),
+        )
+        .map_err(|e| format!("Could not count trajectory events: {e}"))
+    }
+
+    #[allow(dead_code)]
+    pub fn touched_resource_count(&self, run_id: &str) -> Result<usize, String> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT COUNT(*) FROM touched_resources WHERE run_id = ?1",
+            params![run_id],
+            |row| row.get::<_, usize>(0),
+        )
+        .map_err(|e| format!("Could not count touched resources: {e}"))
+    }
+
+    #[allow(dead_code)]
+    pub fn verification_result_count(&self, run_id: &str) -> Result<usize, String> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT COUNT(*) FROM verification_results WHERE run_id = ?1",
+            params![run_id],
+            |row| row.get::<_, usize>(0),
+        )
+        .map_err(|e| format!("Could not count verification results: {e}"))
+    }
+
+    #[allow(dead_code)]
+    pub fn memory_promotion_count(&self, run_id: &str) -> Result<usize, String> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT COUNT(*) FROM memory_promotions WHERE run_id = ?1",
+            params![run_id],
+            |row| row.get::<_, usize>(0),
+        )
+        .map_err(|e| format!("Could not count memory promotions: {e}"))
+    }
+
+    fn connect(&self) -> Result<Connection, String> {
+        let conn = Connection::open(self.db_path.as_path())
+            .map_err(|e| format!("Could not open CutReady agent state database: {e}"))?;
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .map_err(|e| format!("Could not configure agent state database timeout: {e}"))?;
+        Ok(conn)
+    }
+}
+
+impl TrajectorySink for AgentStateStore {
+    fn record(&self, event: TrajectoryEvent) -> Result<(), String> {
+        let conn = self.connect()?;
+        insert_trajectory_event(&conn, self.run_id(), &event)?;
+
+        match &event {
+            TrajectoryEvent::ResourceTouched { resource, .. } => {
+                insert_touched_resource(&conn, self.run_id(), resource)?;
+            }
+            TrajectoryEvent::VerificationRecorded { result, .. } => {
+                insert_verification_result(&conn, self.run_id(), result)?;
+            }
+            TrajectoryEvent::MemoryPromotionSuggested { candidate, .. } => {
+                insert_memory_promotion(&conn, self.run_id(), candidate, None)?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl CheckpointStore for AgentStateStore {
+    fn save_checkpoint(&self, checkpoint: Checkpoint) -> Result<(), String> {
+        let conn = self.connect()?;
+        let run_id = checkpoint
+            .metadata
+            .get("run_id")
+            .map(String::as_str)
+            .unwrap_or_else(|| self.run_id());
+        let checkpoint_json = serde_json::to_string(&checkpoint).map_err(|e| e.to_string())?;
+        conn.execute(
+            "INSERT OR REPLACE INTO checkpoints
+                (id, run_id, created_at, checkpoint_json)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                checkpoint.id,
+                run_id,
+                checkpoint.created_at.to_rfc3339(),
+                checkpoint_json
+            ],
+        )
+        .map_err(|e| format!("Could not save checkpoint: {e}"))?;
+        prune_checkpoints_for_run(&conn, run_id)?;
+        Ok(())
+    }
+
+    fn latest_checkpoint(&self, run_id: &str) -> Result<Option<Checkpoint>, String> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT checkpoint_json FROM checkpoints
+             WHERE run_id = ?1
+             ORDER BY datetime(created_at) DESC, id DESC
+             LIMIT 1",
+            params![run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| format!("Could not read latest checkpoint: {e}"))?
+        .map(|json| serde_json::from_str(&json).map_err(|e| e.to_string()))
+        .transpose()
+    }
+
+    fn list_checkpoints(&self, run_id: &str) -> Result<Vec<Checkpoint>, String> {
+        let conn = self.connect()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT checkpoint_json FROM checkpoints
+                 WHERE run_id = ?1
+                 ORDER BY datetime(created_at) ASC, id ASC",
+            )
+            .map_err(|e| format!("Could not prepare checkpoint query: {e}"))?;
+        let rows = stmt
+            .query_map(params![run_id], |row| row.get::<_, String>(0))
+            .map_err(|e| format!("Could not query checkpoints: {e}"))?;
+
+        let mut checkpoints = Vec::new();
+        for row in rows {
+            let json = row.map_err(|e| format!("Could not read checkpoint row: {e}"))?;
+            checkpoints.push(serde_json::from_str(&json).map_err(|e| e.to_string())?);
+        }
+        Ok(checkpoints)
+    }
+}
+
+impl MemoryPromotionHook for AgentStateStore {
+    fn consider(
+        &self,
+        candidate: MemoryPromotionCandidate,
+    ) -> Result<MemoryPromotionOutcome, String> {
+        let outcome = MemoryPromotionOutcome::Deferred {
+            reason: Some("CutReady memory-promotion UI is not enabled yet".into()),
+        };
+        self.record_memory_promotion_decision(&candidate, Some(&outcome))?;
+        Ok(outcome)
+    }
+}
+
+fn initialize_schema(conn: &Connection) -> Result<(), String> {
+    let existing_version: i32 = conn
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(|e| format!("Could not read agent state schema version: {e}"))?;
+    if existing_version > SCHEMA_VERSION {
+        return Err(format!(
+            "Agent state database schema version {existing_version} is newer than this CutReady build supports ({SCHEMA_VERSION})"
+        ));
+    }
+
+    conn.execute_batch(
+        "
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE IF NOT EXISTS agent_runs (
+            run_id TEXT PRIMARY KEY,
+            parent_run_id TEXT,
+            provider TEXT NOT NULL,
+            model TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            completed_at TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE TABLE IF NOT EXISTS trajectory_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            event_id TEXT,
+            parent_event_id TEXT,
+            iteration INTEGER,
+            event_type TEXT NOT NULL,
+            event_json TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_trajectory_events_run
+            ON trajectory_events (run_id, id);
+        CREATE TABLE IF NOT EXISTS checkpoints (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            checkpoint_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_checkpoints_run
+            ON checkpoints (run_id, created_at);
+        CREATE TABLE IF NOT EXISTS resume_contexts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            checkpoint_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            context_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_resume_contexts_run
+            ON resume_contexts (run_id, id);
+        CREATE TABLE IF NOT EXISTS touched_resources (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            resource_id TEXT NOT NULL,
+            operation TEXT NOT NULL,
+            resource_json TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_touched_resources_run
+            ON touched_resources (run_id, id);
+        CREATE TABLE IF NOT EXISTS verification_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            criterion TEXT NOT NULL,
+            status TEXT NOT NULL,
+            result_json TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_verification_results_run
+            ON verification_results (run_id, id);
+        CREATE TABLE IF NOT EXISTS memory_promotions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            candidate_json TEXT NOT NULL,
+            outcome_json TEXT,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_promotions_run
+            ON memory_promotions (run_id, id);
+        ",
+    )
+    .map_err(|e| format!("Could not initialize agent state schema: {e}"))?;
+    if existing_version < SCHEMA_VERSION {
+        conn.pragma_update(None, "user_version", SCHEMA_VERSION)
+            .map_err(|e| format!("Could not set agent state schema version: {e}"))?;
+    }
+    Ok(())
+}
+
+fn insert_trajectory_event(
+    conn: &Connection,
+    fallback_run_id: &str,
+    event: &TrajectoryEvent,
+) -> Result<(), String> {
+    let metadata = event_metadata(event);
+    let run_id = metadata.run_id.as_deref().unwrap_or(fallback_run_id);
+    let event_json = serde_json::to_string(event).map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO trajectory_events
+            (run_id, event_id, parent_event_id, iteration, event_type, event_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            run_id,
+            metadata.event_id.as_deref(),
+            metadata.parent_event_id.as_deref(),
+            metadata.iteration.map(|value| value as i64),
+            event_type(event),
+            event_json,
+            metadata.timestamp.to_rfc3339(),
+        ],
+    )
+    .map_err(|e| format!("Could not insert trajectory event: {e}"))?;
+    prune_by_run_limit(conn, "trajectory_events", run_id, MAX_EVENTS_PER_RUN)?;
+    Ok(())
+}
+
+fn insert_touched_resource(
+    conn: &Connection,
+    run_id: &str,
+    resource: &TouchedResource,
+) -> Result<(), String> {
+    let resource_json = serde_json::to_string(resource).map_err(|e| e.to_string())?;
+    let operation = serde_json::to_value(&resource.operation)
+        .map_err(|e| e.to_string())?
+        .as_str()
+        .unwrap_or("custom")
+        .to_string();
+    conn.execute(
+        "INSERT INTO touched_resources
+            (run_id, kind, resource_id, operation, resource_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            run_id,
+            resource.kind,
+            resource.id,
+            operation,
+            resource_json,
+            Utc::now().to_rfc3339()
+        ],
+    )
+    .map_err(|e| format!("Could not insert touched resource: {e}"))?;
+    prune_by_run_limit(
+        conn,
+        "touched_resources",
+        run_id,
+        MAX_TOUCHED_RESOURCES_PER_RUN,
+    )?;
+    Ok(())
+}
+
+fn insert_verification_result(
+    conn: &Connection,
+    run_id: &str,
+    result: &VerificationResult,
+) -> Result<(), String> {
+    let result_json = serde_json::to_string(result).map_err(|e| e.to_string())?;
+    let status = serde_json::to_value(&result.status)
+        .map_err(|e| e.to_string())?
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+    conn.execute(
+        "INSERT INTO verification_results
+            (run_id, criterion, status, result_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            run_id,
+            result.criterion,
+            status,
+            result_json,
+            Utc::now().to_rfc3339()
+        ],
+    )
+    .map_err(|e| format!("Could not insert verification result: {e}"))?;
+    prune_by_run_limit(
+        conn,
+        "verification_results",
+        run_id,
+        MAX_VERIFICATION_RESULTS_PER_RUN,
+    )?;
+    Ok(())
+}
+
+fn insert_memory_promotion(
+    conn: &Connection,
+    run_id: &str,
+    candidate: &MemoryPromotionCandidate,
+    outcome: Option<&MemoryPromotionOutcome>,
+) -> Result<(), String> {
+    let candidate_json = serde_json::to_string(candidate).map_err(|e| e.to_string())?;
+    let outcome_json = outcome
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| e.to_string())?;
+    let status = outcome.map(memory_outcome_status).unwrap_or("suggested");
+    conn.execute(
+        "INSERT INTO memory_promotions
+            (run_id, status, candidate_json, outcome_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            run_id,
+            status,
+            candidate_json,
+            outcome_json,
+            Utc::now().to_rfc3339()
+        ],
+    )
+    .map_err(|e| format!("Could not insert memory promotion: {e}"))?;
+    prune_by_run_limit(
+        conn,
+        "memory_promotions",
+        run_id,
+        MAX_MEMORY_PROMOTIONS_PER_RUN,
+    )?;
+    Ok(())
+}
+
+fn prune_completed_runs(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM trajectory_events WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old trajectory events: {e}"))?;
+    conn.execute(
+        "DELETE FROM checkpoints WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old checkpoints: {e}"))?;
+    conn.execute(
+        "DELETE FROM resume_contexts WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old resume contexts: {e}"))?;
+    conn.execute(
+        "DELETE FROM touched_resources WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old touched resources: {e}"))?;
+    conn.execute(
+        "DELETE FROM verification_results WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old verification results: {e}"))?;
+    conn.execute(
+        "DELETE FROM memory_promotions WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old memory promotions: {e}"))?;
+    conn.execute(
+        "DELETE FROM agent_runs WHERE run_id IN (
+            SELECT run_id FROM agent_runs
+            WHERE status != 'running' AND completed_at IS NOT NULL
+            ORDER BY datetime(completed_at) DESC, started_at DESC
+            LIMIT -1 OFFSET ?1
+        )",
+        params![MAX_COMPLETED_RUNS as i64],
+    )
+    .map_err(|e| format!("Could not prune old agent runs: {e}"))?;
+    Ok(())
+}
+
+fn prune_by_run_limit(
+    conn: &Connection,
+    table: &str,
+    run_id: &str,
+    max_rows: usize,
+) -> Result<(), String> {
+    let sql = format!(
+        "DELETE FROM {table}
+         WHERE run_id = ?1
+           AND id NOT IN (
+             SELECT id FROM {table}
+             WHERE run_id = ?1
+             ORDER BY id DESC
+             LIMIT ?2
+           )"
+    );
+    conn.execute(&sql, params![run_id, max_rows as i64])
+        .map_err(|e| format!("Could not prune {table}: {e}"))?;
+    Ok(())
+}
+
+fn prune_checkpoints_for_run(conn: &Connection, run_id: &str) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM checkpoints
+         WHERE run_id = ?1
+           AND id NOT IN (
+             SELECT id FROM checkpoints
+             WHERE run_id = ?1
+             ORDER BY datetime(created_at) DESC, id DESC
+             LIMIT ?2
+           )",
+        params![run_id, MAX_CHECKPOINTS_PER_RUN as i64],
+    )
+    .map_err(|e| format!("Could not prune checkpoints: {e}"))?;
+    Ok(())
+}
+
+fn event_metadata(event: &TrajectoryEvent) -> &TrajectoryMetadata {
+    match event {
+        TrajectoryEvent::TurnStarted { metadata, .. }
+        | TrajectoryEvent::TurnCompleted { metadata, .. }
+        | TrajectoryEvent::ModelCallStarted { metadata, .. }
+        | TrajectoryEvent::ModelCallCompleted { metadata, .. }
+        | TrajectoryEvent::ToolCallStarted { metadata, .. }
+        | TrajectoryEvent::ToolCallCompleted { metadata, .. }
+        | TrajectoryEvent::Permission { metadata, .. }
+        | TrajectoryEvent::RetryScheduled { metadata, .. }
+        | TrajectoryEvent::VerificationRecorded { metadata, .. }
+        | TrajectoryEvent::CheckpointCreated { metadata, .. }
+        | TrajectoryEvent::CompactionStarted { metadata, .. }
+        | TrajectoryEvent::CompactionCompleted { metadata, .. }
+        | TrajectoryEvent::MemoryPromotionSuggested { metadata, .. }
+        | TrajectoryEvent::MemoryPromotionCompleted { metadata, .. }
+        | TrajectoryEvent::ResourceTouched { metadata, .. }
+        | TrajectoryEvent::Custom { metadata, .. } => metadata,
+    }
+}
+
+fn event_type(event: &TrajectoryEvent) -> &'static str {
+    match event {
+        TrajectoryEvent::TurnStarted { .. } => "turn_started",
+        TrajectoryEvent::TurnCompleted { .. } => "turn_completed",
+        TrajectoryEvent::ModelCallStarted { .. } => "model_call_started",
+        TrajectoryEvent::ModelCallCompleted { .. } => "model_call_completed",
+        TrajectoryEvent::ToolCallStarted { .. } => "tool_call_started",
+        TrajectoryEvent::ToolCallCompleted { .. } => "tool_call_completed",
+        TrajectoryEvent::Permission { .. } => "permission",
+        TrajectoryEvent::RetryScheduled { .. } => "retry_scheduled",
+        TrajectoryEvent::VerificationRecorded { .. } => "verification_recorded",
+        TrajectoryEvent::CheckpointCreated { .. } => "checkpoint_created",
+        TrajectoryEvent::CompactionStarted { .. } => "compaction_started",
+        TrajectoryEvent::CompactionCompleted { .. } => "compaction_completed",
+        TrajectoryEvent::MemoryPromotionSuggested { .. } => "memory_promotion_suggested",
+        TrajectoryEvent::MemoryPromotionCompleted { .. } => "memory_promotion_completed",
+        TrajectoryEvent::ResourceTouched { .. } => "resource_touched",
+        TrajectoryEvent::Custom { .. } => "custom",
+    }
+}
+
+fn memory_outcome_status(outcome: &MemoryPromotionOutcome) -> &'static str {
+    match outcome {
+        MemoryPromotionOutcome::Accepted { .. } => "accepted",
+        MemoryPromotionOutcome::Rejected { .. } => "rejected",
+        MemoryPromotionOutcome::Deferred { .. } => "deferred",
+        MemoryPromotionOutcome::Failed { .. } => "failed",
+    }
+}
+
+fn parse_rfc3339_row(value: String, column: usize) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(&value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                column,
+                rusqlite::types::Type::Text,
+                Box::new(err),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentive::{
+        CheckpointStore, ErrorKind, ResourceOperation, TrajectoryMetadata, VerificationStatus,
+    };
+
+    fn test_store(run_id: &str) -> AgentStateStore {
+        let dir = tempfile::tempdir().unwrap().keep();
+        AgentStateStore::for_database_path(dir.join(".cutready").join("agent-state.db"), run_id)
+            .unwrap()
+    }
+
+    #[test]
+    fn schema_initializes_idempotently() {
+        let store = test_store("run-schema");
+        store.initialize().unwrap();
+        store.initialize().unwrap();
+
+        let conn = Connection::open(store.db_path()).unwrap();
+        let version: i32 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn schema_rejects_newer_database_versions() {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let db_path = dir.join(".cutready").join("agent-state.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "user_version", SCHEMA_VERSION + 1)
+            .unwrap();
+        drop(conn);
+
+        let err = AgentStateStore::for_database_path(db_path, "run-newer-schema").unwrap_err();
+        assert!(err.contains("newer than this CutReady build supports"));
+    }
+
+    #[test]
+    fn run_event_checkpoint_and_resume_context_round_trip() {
+        let store = test_store("run-round-trip");
+        store
+            .insert_run(
+                None,
+                "openai",
+                "gpt-4o",
+                serde_json::json!({"source":"test"}),
+            )
+            .unwrap();
+
+        store
+            .record(TrajectoryEvent::TurnStarted {
+                metadata: TrajectoryMetadata::new().with_run_id("run-round-trip"),
+                goal: "Improve sketch".into(),
+            })
+            .unwrap();
+
+        let checkpoint = Checkpoint::new("checkpoint-1", "Improve sketch")
+            .with_metadata("run_id", "run-round-trip")
+            .with_next_step("Verify update");
+        store.save_checkpoint(checkpoint.clone()).unwrap();
+        store
+            .save_resume_context(ResumeContext::new(checkpoint.clone()))
+            .unwrap();
+
+        let run = store.get_run("run-round-trip").unwrap().unwrap();
+        assert_eq!(run.status, "running");
+        assert_eq!(store.trajectory_event_count("run-round-trip").unwrap(), 1);
+        assert_eq!(
+            store
+                .latest_checkpoint("run-round-trip")
+                .unwrap()
+                .unwrap()
+                .id,
+            checkpoint.id
+        );
+        assert_eq!(store.list_checkpoints("run-round-trip").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn resource_verification_and_memory_records_use_agentive_types() {
+        let store = test_store("run-metadata");
+        let resource = TouchedResource::new("sketch", "intro.sk", ResourceOperation::Write)
+            .with_metadata("tool", "write_sketch");
+        let verification = VerificationResult::new(
+            "Tool write_sketch completed",
+            VerificationStatus::Passed,
+            "Tool returned a success response",
+        );
+        let candidate = MemoryPromotionCandidate::new("User prefers concise narration")
+            .with_category("core")
+            .with_tag("preference");
+
+        let resource_json = serde_json::to_string(&resource).unwrap();
+        let verification_json = serde_json::to_string(&verification).unwrap();
+        let candidate_json = serde_json::to_string(&candidate).unwrap();
+        assert_eq!(
+            serde_json::from_str::<TouchedResource>(&resource_json).unwrap(),
+            resource
+        );
+        assert_eq!(
+            serde_json::from_str::<VerificationResult>(&verification_json).unwrap(),
+            verification
+        );
+        assert_eq!(
+            serde_json::from_str::<MemoryPromotionCandidate>(&candidate_json).unwrap(),
+            candidate
+        );
+
+        store.record_touched_resource(&resource).unwrap();
+        store.record_verification_result(&verification).unwrap();
+        let outcome = MemoryPromotionOutcome::Failed {
+            failure_kind: ErrorKind::ToolError,
+            reason: "test hook failure".into(),
+        };
+        store
+            .record_memory_promotion_decision(&candidate, Some(&outcome))
+            .unwrap();
+
+        assert_eq!(store.touched_resource_count("run-metadata").unwrap(), 1);
+        assert_eq!(store.verification_result_count("run-metadata").unwrap(), 1);
+        assert_eq!(store.memory_promotion_count("run-metadata").unwrap(), 1);
+    }
+
+    #[test]
+    fn trajectory_sink_extracts_resource_and_verification_records() {
+        let store = test_store("run-trajectory");
+        let metadata = TrajectoryMetadata::new().with_run_id("run-trajectory");
+        store
+            .record(TrajectoryEvent::ResourceTouched {
+                metadata: metadata.clone(),
+                resource: TouchedResource::new("note", "plan.md", ResourceOperation::Read),
+            })
+            .unwrap();
+        store
+            .record(TrajectoryEvent::VerificationRecorded {
+                metadata,
+                result: VerificationResult::new(
+                    "Tool read_note completed",
+                    VerificationStatus::Passed,
+                    "Read note content",
+                ),
+            })
+            .unwrap();
+
+        assert_eq!(store.trajectory_event_count("run-trajectory").unwrap(), 2);
+        assert_eq!(store.touched_resource_count("run-trajectory").unwrap(), 1);
+        assert_eq!(
+            store.verification_result_count("run-trajectory").unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn retention_caps_append_only_rows_per_run() {
+        let store = test_store("run-retention");
+        for index in 0..(MAX_EVENTS_PER_RUN + 5) {
+            store
+                .record(TrajectoryEvent::Custom {
+                    metadata: TrajectoryMetadata::new()
+                        .with_run_id("run-retention")
+                        .with_event_id(format!("event-{index}")),
+                    name: "test".into(),
+                    fields: Default::default(),
+                })
+                .unwrap();
+        }
+
+        assert_eq!(
+            store.trajectory_event_count("run-retention").unwrap(),
+            MAX_EVENTS_PER_RUN
+        );
+    }
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod agent_state;
 pub mod animation;
 pub mod automation;
 pub mod export;


### PR DESCRIPTION
CutReady's agent loop now needs a durable observability foundation before we add user-facing Conversation Mode and resume workflows. This PR adopts agentive 0.2.1's host-neutral run-state primitives while keeping CutReady in charge of storage policy and preserving the current frontend agent stream.

## Summary

- Switches `agentive` from the git dependency to crates.io `0.2.1` with the optional `tracing` feature enabled.
- Adds a CutReady-owned project SQLite store at `.cutready/agent-state.db` for agent runs, trajectory events, checkpoints, resume contexts, touched resources, verification results, and memory-promotion decisions.
- Wires `agent_chat_with_tools` and the agent runner to record agentive trajectory and memory-promotion events without changing existing frontend `AgentEvent` behavior.
- Adds obvious touched-resource and verification metadata for CutReady tools such as sketches, storyboards, notes, visuals, web fetch, and web search.
- Keeps persistence best-effort so a corrupt, locked, or unwritable agent-state database does not block chat startup.

## Review notes

The SQLite store includes initial retention caps and schema-version downgrade protection. Resume is intentionally not enabled in the UI yet; this PR only lays the silent backend foundation so the stored state can be inspected and productized in a follow-up.

## Validation

- `cargo test` in `src-tauri` passed.
- Architecture-focused review pass completed; findings around best-effort persistence, retention, and schema safety were addressed before commit.